### PR TITLE
strip leading slash

### DIFF
--- a/lib/ddex/ern.rb
+++ b/lib/ddex/ern.rb
@@ -63,7 +63,7 @@ module DDEX
       raise ArgumentError, "options must be a Hash" unless options.is_a?(Hash)
 
       doc = parse(xml, options)
-      ver = doc.root[VERSION_ATTR]
+      ver = doc.root[VERSION_ATTR].gsub!(/^\//, "")
       raise_unknown_version(ver) unless config.include?(ver)
 
       klass = load_version(ver)


### PR DESCRIPTION
While working with SONY Music DDEX files I encountered an error where a leading slash ("/") was causing the version validation to fail.  Remove any leading slashes when checking version.

```
MessageSchemaVersionId="/ern/341"
```

vs

```
MessageSchemaVersionId="ern/341"
```
