### PR TITLE
Update icpn.rb

### DIFF
--- a/lib/ddex/v20120404/ddexc/icpn.rb
+++ b/lib/ddex/v20120404/ddexc/icpn.rb
@@ -19,7 +19,7 @@ class ICPN < Element
     xml_accessor :value, :from => ".", :required => false
 
   
-      xml_accessor :ean?, :from => "@IsEan", :required => true
+      xml_accessor :isean, :from => "@IsEan", :required => true
     
   
 


### PR DESCRIPTION
when using :ean? instead of :isean to write the IsEan attribute it doesn't seem to work.
