### PR TITLE
Fallback to checking the version directly when MessageSchemaVersionId is invalid

### DIFF
--- a/lib/ddex/ern.rb
+++ b/lib/ddex/ern.rb
@@ -146,7 +146,9 @@ module DDEX
 
       # Some normalization
       v = version.strip.gsub(%r{//+}, "/").gsub(%r{\A/|/\Z}, "")
-      klass, _ = config.find { |name, cfg| cfg[:message_schema_version_id] == v }
+      klass, _ = config.find do |name, cfg|
+        cfg[:message_schema_version_id] == v || cfg[:version] == v
+      end
       raise_unknown_version(version) unless klass
 
       # >= 2.0 allows for one call

--- a/spec/ern_spec.rb
+++ b/spec/ern_spec.rb
@@ -83,7 +83,7 @@ describe DDEX::ERN do
 
   describe ".read" do
     describe "MessageSchemaVersionId detection" do
-      %w[/ern/35 ern/35/ //ern/35//].each do |v|
+      %w[/ern/35 ern/35/ //ern/35// 3.5].each do |v|
         it "parses #{v} as ERN 3.5" do
           doc = load_fixture("ern/35/instance1")
           doc.root["MessageSchemaVersionId"] = v


### PR DESCRIPTION
We were getting XML files from suppliers like `instance3.xml` with the MessageSchemaVersionId="3.7" but the library still seemed to *nearly* detect the version correctly.

Let me know if this is wrong or bad or anything. :smile: