### PR TITLE
Remove extra 'ns1' namespace from the beginning of every XML element name (ERN 3.8 and 3.8.1)

### DIFF
--- a/lib/ddex/ern/v38/administrating_record_company.rb
+++ b/lib/ddex/ern/v38/administrating_record_company.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::AdministratingRecordCompany < Element
   include ROXML
 
 
-  xml_name "ns1:AdministratingRecordCompany"
+  xml_name "AdministratingRecordCompany"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/all_territory_code.rb
+++ b/lib/ddex/ern/v38/all_territory_code.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::AllTerritoryCode < Element
   include ROXML
 
 
-  xml_name "ns1:AllTerritoryCode"
+  xml_name "AllTerritoryCode"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/artist.rb
+++ b/lib/ddex/ern/v38/artist.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::Artist < Element
   include ROXML
 
 
-  xml_name "ns1:Artist"
+  xml_name "Artist"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/artist_delegated_usage_rights.rb
+++ b/lib/ddex/ern/v38/artist_delegated_usage_rights.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::ArtistDelegatedUsageRights < Element
   include ROXML
 
 
-  xml_name "ns1:ArtistDelegatedUsageRights"
+  xml_name "ArtistDelegatedUsageRights"
 
       xml_accessor :use_types, :as => [DDEX::ERN::V38::UseType], :from => "UseType", :required => true
       xml_accessor :user_interface_types, :as => [DDEX::ERN::V38::UserInterfaceType], :from => "UserInterfaceType", :required => false

--- a/lib/ddex/ern/v38/artist_role.rb
+++ b/lib/ddex/ern/v38/artist_role.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ArtistRole < Element
   include ROXML
 
 
-  xml_name "ns1:ArtistRole"
+  xml_name "ArtistRole"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/aspect_ratio.rb
+++ b/lib/ddex/ern/v38/aspect_ratio.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::AspectRatio < Element
   include ROXML
 
 
-  xml_name "ns1:AspectRatio"
+  xml_name "AspectRatio"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/audio_codec_type.rb
+++ b/lib/ddex/ern/v38/audio_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::AudioCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:AudioCodecType"
+  xml_name "AudioCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/av_rating.rb
+++ b/lib/ddex/ern/v38/av_rating.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::AvRating < Element
   include ROXML
 
 
-  xml_name "ns1:AvRating"
+  xml_name "AvRating"
 
       xml_accessor :rating_text, :from => "RatingText", :required => true
       xml_accessor :rating_agency, :as => DDEX::ERN::V38::RatingAgency, :from => "RatingAgency", :required => true

--- a/lib/ddex/ern/v38/bit_rate.rb
+++ b/lib/ddex/ern/v38/bit_rate.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::BitRate < Element
   include ROXML
 
 
-  xml_name "ns1:BitRate"
+  xml_name "BitRate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/c_line.rb
+++ b/lib/ddex/ern/v38/c_line.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CLine < Element
   include ROXML
 
 
-  xml_name "ns1:CLine"
+  xml_name "CLine"
 
       xml_accessor :year, :from => "Year", :required => false
       xml_accessor :c_line_company, :from => "CLineCompany", :required => false

--- a/lib/ddex/ern/v38/carrier_type.rb
+++ b/lib/ddex/ern/v38/carrier_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CarrierType < Element
   include ROXML
 
 
-  xml_name "ns1:CarrierType"
+  xml_name "CarrierType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/catalog_item.rb
+++ b/lib/ddex/ern/v38/catalog_item.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V38::CatalogItem < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogItem"
+  xml_name "CatalogItem"
 
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::AllTerritoryCode], :from => "TerritoryCode", :required => true
       xml_accessor :release_ids, :as => [DDEX::ERN::V38::ReleaseId], :from => "ReleaseId", :required => true

--- a/lib/ddex/ern/v38/catalog_list_message.rb
+++ b/lib/ddex/ern/v38/catalog_list_message.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::CatalogListMessage < Element
 
     setns "ns1", "http://ddex.net/xml/ern/38"
 
-  xml_name "ns1:CatalogListMessage"
+  xml_name "CatalogListMessage"
 
       xml_accessor :message_header, :as => DDEX::ERN::V38::MessageHeader, :from => "MessageHeader", :required => true
       xml_accessor :publication_date, :as => DateTime, :from => "PublicationDate", :required => true

--- a/lib/ddex/ern/v38/catalog_number.rb
+++ b/lib/ddex/ern/v38/catalog_number.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CatalogNumber < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogNumber"
+  xml_name "CatalogNumber"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/catalog_release_reference_list.rb
+++ b/lib/ddex/ern/v38/catalog_release_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CatalogReleaseReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogReleaseReferenceList"
+  xml_name "CatalogReleaseReferenceList"
 
       xml_accessor :catalog_release_references, :as => [], :from => "CatalogReleaseReference", :required => true
 

--- a/lib/ddex/ern/v38/catalog_transfer.rb
+++ b/lib/ddex/ern/v38/catalog_transfer.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::CatalogTransfer < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogTransfer"
+  xml_name "CatalogTransfer"
 
       xml_accessor :catalog_transfer_completed?, :from => "CatalogTransferCompleted", :required => false
       xml_accessor :effective_transfer_date, :as => DDEX::ERN::V38::EventDate, :from => "EffectiveTransferDate", :required => false

--- a/lib/ddex/ern/v38/character.rb
+++ b/lib/ddex/ern/v38/character.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::Character < Element
   include ROXML
 
 
-  xml_name "ns1:Character"
+  xml_name "Character"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/collection.rb
+++ b/lib/ddex/ern/v38/collection.rb
@@ -29,7 +29,7 @@ class DDEX::ERN::V38::Collection < Element
   include ROXML
 
 
-  xml_name "ns1:Collection"
+  xml_name "Collection"
 
       xml_accessor :collection_ids, :as => [DDEX::ERN::V38::CollectionId], :from => "CollectionId", :required => true
       xml_accessor :collection_types, :as => [DDEX::ERN::V38::CollectionType], :from => "CollectionType", :required => false

--- a/lib/ddex/ern/v38/collection_collection_reference.rb
+++ b/lib/ddex/ern/v38/collection_collection_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CollectionCollectionReference < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionCollectionReference"
+  xml_name "CollectionCollectionReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :collection_collection_reference, :from => "CollectionCollectionReference", :required => true

--- a/lib/ddex/ern/v38/collection_collection_reference_list.rb
+++ b/lib/ddex/ern/v38/collection_collection_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::CollectionCollectionReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionCollectionReferenceList"
+  xml_name "CollectionCollectionReferenceList"
 
       xml_accessor :number_of_collections, :as => Integer, :from => "NumberOfCollections", :required => false
       xml_accessor :collection_collection_references, :as => [DDEX::ERN::V38::CollectionCollectionReference], :from => "CollectionCollectionReference", :required => true

--- a/lib/ddex/ern/v38/collection_details_by_territory.rb
+++ b/lib/ddex/ern/v38/collection_details_by_territory.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::CollectionDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionDetailsByTerritory"
+  xml_name "CollectionDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/collection_id.rb
+++ b/lib/ddex/ern/v38/collection_id.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::CollectionId < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionId"
+  xml_name "CollectionId"
 
       xml_accessor :g_rid, :from => "GRid", :required => false
       xml_accessor :isrc, :from => "ISRC", :required => false

--- a/lib/ddex/ern/v38/collection_list.rb
+++ b/lib/ddex/ern/v38/collection_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::CollectionList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionList"
+  xml_name "CollectionList"
 
       xml_accessor :collections, :as => [DDEX::ERN::V38::Collection], :from => "Collection", :required => true
 

--- a/lib/ddex/ern/v38/collection_resource_reference.rb
+++ b/lib/ddex/ern/v38/collection_resource_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CollectionResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionResourceReference"
+  xml_name "CollectionResourceReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :collection_resource_reference, :from => "CollectionResourceReference", :required => true

--- a/lib/ddex/ern/v38/collection_resource_reference_list.rb
+++ b/lib/ddex/ern/v38/collection_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::CollectionResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionResourceReferenceList"
+  xml_name "CollectionResourceReferenceList"
 
       xml_accessor :collection_resource_references, :as => [DDEX::ERN::V38::CollectionResourceReference], :from => "CollectionResourceReference", :required => true
 

--- a/lib/ddex/ern/v38/collection_type.rb
+++ b/lib/ddex/ern/v38/collection_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CollectionType < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionType"
+  xml_name "CollectionType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/collection_work_reference.rb
+++ b/lib/ddex/ern/v38/collection_work_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CollectionWorkReference < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionWorkReference"
+  xml_name "CollectionWorkReference"
 
       xml_accessor :collection_work_reference, :from => "CollectionWorkReference", :required => true
       xml_accessor :duration, :from => "Duration", :required => false

--- a/lib/ddex/ern/v38/collection_work_reference_list.rb
+++ b/lib/ddex/ern/v38/collection_work_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::CollectionWorkReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionWorkReferenceList"
+  xml_name "CollectionWorkReferenceList"
 
       xml_accessor :collection_work_references, :as => [DDEX::ERN::V38::CollectionWorkReference], :from => "CollectionWorkReference", :required => true
 

--- a/lib/ddex/ern/v38/comment.rb
+++ b/lib/ddex/ern/v38/comment.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Comment < Element
   include ROXML
 
 
-  xml_name "ns1:Comment"
+  xml_name "Comment"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/commercial_model_type.rb
+++ b/lib/ddex/ern/v38/commercial_model_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CommercialModelType < Element
   include ROXML
 
 
-  xml_name "ns1:CommercialModelType"
+  xml_name "CommercialModelType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/condition.rb
+++ b/lib/ddex/ern/v38/condition.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Condition < Element
   include ROXML
 
 
-  xml_name "ns1:Condition"
+  xml_name "Condition"
 
       xml_accessor :value, :as => Float, :from => "Value", :required => true
       xml_accessor :unit, :from => "Unit", :required => true

--- a/lib/ddex/ern/v38/consumer_rental_period.rb
+++ b/lib/ddex/ern/v38/consumer_rental_period.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ConsumerRentalPeriod < Element
   include ROXML
 
 
-  xml_name "ns1:ConsumerRentalPeriod"
+  xml_name "ConsumerRentalPeriod"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/contact_id.rb
+++ b/lib/ddex/ern/v38/contact_id.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ContactId < Element
   include ROXML
 
 
-  xml_name "ns1:ContactId"
+  xml_name "ContactId"
 
       xml_accessor :email_addresses, :as => [], :from => "EmailAddress", :required => false
       xml_accessor :phone_numbers, :as => [], :from => "PhoneNumber", :required => false

--- a/lib/ddex/ern/v38/container_format.rb
+++ b/lib/ddex/ern/v38/container_format.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ContainerFormat < Element
   include ROXML
 
 
-  xml_name "ns1:ContainerFormat"
+  xml_name "ContainerFormat"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/courtesy_line.rb
+++ b/lib/ddex/ern/v38/courtesy_line.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CourtesyLine < Element
   include ROXML
 
 
-  xml_name "ns1:CourtesyLine"
+  xml_name "CourtesyLine"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/creation_id.rb
+++ b/lib/ddex/ern/v38/creation_id.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::CreationId < Element
   include ROXML
 
 
-  xml_name "ns1:CreationId"
+  xml_name "CreationId"
 
       xml_accessor :iswc, :from => "ISWC", :required => false
       xml_accessor :opus_number, :from => "OpusNumber", :required => false

--- a/lib/ddex/ern/v38/cue.rb
+++ b/lib/ddex/ern/v38/cue.rb
@@ -30,7 +30,7 @@ class DDEX::ERN::V38::Cue < Element
   include ROXML
 
 
-  xml_name "ns1:Cue"
+  xml_name "Cue"
 
       xml_accessor :cue_use_type, :as => DDEX::ERN::V38::CueUseType, :from => "CueUseType", :required => false
       xml_accessor :cue_theme_type, :as => DDEX::ERN::V38::CueThemeType, :from => "CueThemeType", :required => false

--- a/lib/ddex/ern/v38/cue_creation_reference.rb
+++ b/lib/ddex/ern/v38/cue_creation_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueCreationReference < Element
   include ROXML
 
 
-  xml_name "ns1:CueCreationReference"
+  xml_name "CueCreationReference"
 
       xml_accessor :cue_resource_reference, :from => "CueResourceReference", :required => false
       xml_accessor :cue_work_reference, :from => "CueWorkReference", :required => false

--- a/lib/ddex/ern/v38/cue_origin.rb
+++ b/lib/ddex/ern/v38/cue_origin.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueOrigin < Element
   include ROXML
 
 
-  xml_name "ns1:CueOrigin"
+  xml_name "CueOrigin"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/cue_sheet.rb
+++ b/lib/ddex/ern/v38/cue_sheet.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::CueSheet < Element
   include ROXML
 
 
-  xml_name "ns1:CueSheet"
+  xml_name "CueSheet"
 
       xml_accessor :cue_sheet_ids, :as => [DDEX::ERN::V38::ProprietaryId], :from => "CueSheetId", :required => false
       xml_accessor :cue_sheet_reference, :from => "CueSheetReference", :required => true

--- a/lib/ddex/ern/v38/cue_sheet_list.rb
+++ b/lib/ddex/ern/v38/cue_sheet_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::CueSheetList < Element
   include ROXML
 
 
-  xml_name "ns1:CueSheetList"
+  xml_name "CueSheetList"
 
       xml_accessor :cue_sheets, :as => [DDEX::ERN::V38::CueSheet], :from => "CueSheet", :required => true
 

--- a/lib/ddex/ern/v38/cue_sheet_type.rb
+++ b/lib/ddex/ern/v38/cue_sheet_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueSheetType < Element
   include ROXML
 
 
-  xml_name "ns1:CueSheetType"
+  xml_name "CueSheetType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/cue_theme_type.rb
+++ b/lib/ddex/ern/v38/cue_theme_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueThemeType < Element
   include ROXML
 
 
-  xml_name "ns1:CueThemeType"
+  xml_name "CueThemeType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/cue_use_type.rb
+++ b/lib/ddex/ern/v38/cue_use_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueUseType < Element
   include ROXML
 
 
-  xml_name "ns1:CueUseType"
+  xml_name "CueUseType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/cue_visual_perception_type.rb
+++ b/lib/ddex/ern/v38/cue_visual_perception_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueVisualPerceptionType < Element
   include ROXML
 
 
-  xml_name "ns1:CueVisualPerceptionType"
+  xml_name "CueVisualPerceptionType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/cue_vocal_type.rb
+++ b/lib/ddex/ern/v38/cue_vocal_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CueVocalType < Element
   include ROXML
 
 
-  xml_name "ns1:CueVocalType"
+  xml_name "CueVocalType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/current_territory_code.rb
+++ b/lib/ddex/ern/v38/current_territory_code.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::CurrentTerritoryCode < Element
   include ROXML
 
 
-  xml_name "ns1:CurrentTerritoryCode"
+  xml_name "CurrentTerritoryCode"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/deal.rb
+++ b/lib/ddex/ern/v38/deal.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V38::Deal < Element
   include ROXML
 
 
-  xml_name "ns1:Deal"
+  xml_name "Deal"
 
       xml_accessor :deal_references, :as => [DDEX::ERN::V38::DealReference], :from => "DealReference", :required => false
       xml_accessor :deal_terms, :as => DDEX::ERN::V38::DealTerms, :from => "DealTerms", :required => false

--- a/lib/ddex/ern/v38/deal_list.rb
+++ b/lib/ddex/ern/v38/deal_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::DealList < Element
   include ROXML
 
 
-  xml_name "ns1:DealList"
+  xml_name "DealList"
 
       xml_accessor :release_deals, :as => [DDEX::ERN::V38::ReleaseDeal], :from => "ReleaseDeal", :required => false
 

--- a/lib/ddex/ern/v38/deal_reference.rb
+++ b/lib/ddex/ern/v38/deal_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::DealReference < Element
   include ROXML
 
 
-  xml_name "ns1:DealReference"
+  xml_name "DealReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/deal_resource_reference_list.rb
+++ b/lib/ddex/ern/v38/deal_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::DealResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:DealResourceReferenceList"
+  xml_name "DealResourceReferenceList"
 
       xml_accessor :deal_resource_references, :as => [], :from => "DealResourceReference", :required => true
       xml_accessor :period, :as => DDEX::ERN::V38::Period, :from => "Period", :required => false

--- a/lib/ddex/ern/v38/deal_technical_resource_details_reference_list.rb
+++ b/lib/ddex/ern/v38/deal_technical_resource_details_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::DealTechnicalResourceDetailsReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:DealTechnicalResourceDetailsReferenceList"
+  xml_name "DealTechnicalResourceDetailsReferenceList"
 
       xml_accessor :deal_technical_resource_details_references, :as => [], :from => "DealTechnicalResourceDetailsReference", :required => true
 

--- a/lib/ddex/ern/v38/deal_terms.rb
+++ b/lib/ddex/ern/v38/deal_terms.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V38::DealTerms < Element
   include ROXML
 
 
-  xml_name "ns1:DealTerms"
+  xml_name "DealTerms"
 
       xml_accessor :pre_order_deal?, :from => "IsPreOrderDeal", :required => false
       xml_accessor :commercial_model_types, :as => [DDEX::ERN::V38::CommercialModelType], :from => "CommercialModelType", :required => false

--- a/lib/ddex/ern/v38/description.rb
+++ b/lib/ddex/ern/v38/description.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Description < Element
   include ROXML
 
 
-  xml_name "ns1:Description"
+  xml_name "Description"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/detailed_resource_contributor.rb
+++ b/lib/ddex/ern/v38/detailed_resource_contributor.rb
@@ -30,7 +30,7 @@ class DDEX::ERN::V38::DetailedResourceContributor < Element
   include ROXML
 
 
-  xml_name "ns1:DetailedResourceContributor"
+  xml_name "DetailedResourceContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/distribution_channel_type.rb
+++ b/lib/ddex/ern/v38/distribution_channel_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::DistributionChannelType < Element
   include ROXML
 
 
-  xml_name "ns1:DistributionChannelType"
+  xml_name "DistributionChannelType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/drm_platform_type.rb
+++ b/lib/ddex/ern/v38/drm_platform_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::DrmPlatformType < Element
   include ROXML
 
 
-  xml_name "ns1:DrmPlatformType"
+  xml_name "DrmPlatformType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/dsp.rb
+++ b/lib/ddex/ern/v38/dsp.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::DSP < Element
   include ROXML
 
 
-  xml_name "ns1:DSP"
+  xml_name "DSP"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/event_date.rb
+++ b/lib/ddex/ern/v38/event_date.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::EventDate < Element
   include ROXML
 
 
-  xml_name "ns1:EventDate"
+  xml_name "EventDate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/event_date_time.rb
+++ b/lib/ddex/ern/v38/event_date_time.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::EventDateTime < Element
   include ROXML
 
 
-  xml_name "ns1:EventDateTime"
+  xml_name "EventDateTime"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/extended_resource_group_content_item.rb
+++ b/lib/ddex/ern/v38/extended_resource_group_content_item.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::ExtendedResourceGroupContentItem < Element
   include ROXML
 
 
-  xml_name "ns1:ExtendedResourceGroupContentItem"
+  xml_name "ExtendedResourceGroupContentItem"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :sequence_sub_number, :as => Integer, :from => "SequenceSubNumber", :required => false

--- a/lib/ddex/ern/v38/extent.rb
+++ b/lib/ddex/ern/v38/extent.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Extent < Element
   include ROXML
 
 
-  xml_name "ns1:Extent"
+  xml_name "Extent"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/external_resource_link.rb
+++ b/lib/ddex/ern/v38/external_resource_link.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::ExternalResourceLink < Element
   include ROXML
 
 
-  xml_name "ns1:ExternalResourceLink"
+  xml_name "ExternalResourceLink"
 
       xml_accessor :urls, :as => [], :from => "URL", :required => true
       xml_accessor :validity_period, :as => DDEX::ERN::V38::Period, :from => "ValidityPeriod", :required => false

--- a/lib/ddex/ern/v38/externally_linked_resource_type.rb
+++ b/lib/ddex/ern/v38/externally_linked_resource_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ExternallyLinkedResourceType < Element
   include ROXML
 
 
-  xml_name "ns1:ExternallyLinkedResourceType"
+  xml_name "ExternallyLinkedResourceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/file.rb
+++ b/lib/ddex/ern/v38/file.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::File < Element
   include ROXML
 
 
-  xml_name "ns1:File"
+  xml_name "File"
 
       xml_accessor :url, :from => "URL", :required => false
       xml_accessor :file_name, :from => "FileName", :required => false

--- a/lib/ddex/ern/v38/fingerprint.rb
+++ b/lib/ddex/ern/v38/fingerprint.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::Fingerprint < Element
   include ROXML
 
 
-  xml_name "ns1:Fingerprint"
+  xml_name "Fingerprint"
 
       xml_accessor :fingerprint, :from => "Fingerprint", :required => true
       xml_accessor :fingerprint_algorithm_type, :as => DDEX::ERN::V38::FingerprintAlgorithmType, :from => "FingerprintAlgorithmType", :required => true

--- a/lib/ddex/ern/v38/fingerprint_algorithm_type.rb
+++ b/lib/ddex/ern/v38/fingerprint_algorithm_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::FingerprintAlgorithmType < Element
   include ROXML
 
 
-  xml_name "ns1:FingerprintAlgorithmType"
+  xml_name "FingerprintAlgorithmType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/frame_rate.rb
+++ b/lib/ddex/ern/v38/frame_rate.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::FrameRate < Element
   include ROXML
 
 
-  xml_name "ns1:FrameRate"
+  xml_name "FrameRate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/fulfillment_date.rb
+++ b/lib/ddex/ern/v38/fulfillment_date.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::FulfillmentDate < Element
   include ROXML
 
 
-  xml_name "ns1:FulfillmentDate"
+  xml_name "FulfillmentDate"
 
       xml_accessor :fulfillment_date, :from => "FulfillmentDate", :required => true
       xml_accessor :resource_release_references, :as => [], :from => "ResourceReleaseReference", :required => false

--- a/lib/ddex/ern/v38/genre.rb
+++ b/lib/ddex/ern/v38/genre.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::Genre < Element
   include ROXML
 
 
-  xml_name "ns1:Genre"
+  xml_name "Genre"
 
       xml_accessor :genre_text, :as => DDEX::ERN::V38::Description, :from => "GenreText", :required => true
       xml_accessor :sub_genre, :as => DDEX::ERN::V38::Description, :from => "SubGenre", :required => false

--- a/lib/ddex/ern/v38/governing_agreement_type.rb
+++ b/lib/ddex/ern/v38/governing_agreement_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::GoverningAgreementType < Element
   include ROXML
 
 
-  xml_name "ns1:GoverningAgreementType"
+  xml_name "GoverningAgreementType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/hash_sum.rb
+++ b/lib/ddex/ern/v38/hash_sum.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::HashSum < Element
   include ROXML
 
 
-  xml_name "ns1:HashSum"
+  xml_name "HashSum"
 
       xml_accessor :hash_sum, :from => "HashSum", :required => true
       xml_accessor :hash_sum_algorithm_type, :as => DDEX::ERN::V38::HashSumAlgorithmType, :from => "HashSumAlgorithmType", :required => true

--- a/lib/ddex/ern/v38/hash_sum_algorithm_type.rb
+++ b/lib/ddex/ern/v38/hash_sum_algorithm_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::HashSumAlgorithmType < Element
   include ROXML
 
 
-  xml_name "ns1:HashSumAlgorithmType"
+  xml_name "HashSumAlgorithmType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/host_sound_carrier.rb
+++ b/lib/ddex/ern/v38/host_sound_carrier.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V38::HostSoundCarrier < Element
   include ROXML
 
 
-  xml_name "ns1:HostSoundCarrier"
+  xml_name "HostSoundCarrier"
 
       xml_accessor :release_ids, :as => [DDEX::ERN::V38::ReleaseId], :from => "ReleaseId", :required => false
       xml_accessor :rights_agreement_id, :as => DDEX::ERN::V38::RightsAgreementId, :from => "RightsAgreementId", :required => false

--- a/lib/ddex/ern/v38/icpn.rb
+++ b/lib/ddex/ern/v38/icpn.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ICPN < Element
   include ROXML
 
 
-  xml_name "ns1:ICPN"
+  xml_name "ICPN"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/image.rb
+++ b/lib/ddex/ern/v38/image.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V38::Image < Element
   include ROXML
 
 
-  xml_name "ns1:Image"
+  xml_name "Image"
 
       xml_accessor :image_type, :as => DDEX::ERN::V38::ImageType, :from => "ImageType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/image_codec_type.rb
+++ b/lib/ddex/ern/v38/image_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ImageCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:ImageCodecType"
+  xml_name "ImageCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/image_details_by_territory.rb
+++ b/lib/ddex/ern/v38/image_details_by_territory.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V38::ImageDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:ImageDetailsByTerritory"
+  xml_name "ImageDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/image_type.rb
+++ b/lib/ddex/ern/v38/image_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ImageType < Element
   include ROXML
 
 
-  xml_name "ns1:ImageType"
+  xml_name "ImageType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/indirect_resource_contributor.rb
+++ b/lib/ddex/ern/v38/indirect_resource_contributor.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::IndirectResourceContributor < Element
   include ROXML
 
 
-  xml_name "ns1:IndirectResourceContributor"
+  xml_name "IndirectResourceContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/keywords.rb
+++ b/lib/ddex/ern/v38/keywords.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Keywords < Element
   include ROXML
 
 
-  xml_name "ns1:Keywords"
+  xml_name "Keywords"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/label_name.rb
+++ b/lib/ddex/ern/v38/label_name.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::LabelName < Element
   include ROXML
 
 
-  xml_name "ns1:LabelName"
+  xml_name "LabelName"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/linked_release_resource_reference.rb
+++ b/lib/ddex/ern/v38/linked_release_resource_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::LinkedReleaseResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:LinkedReleaseResourceReference"
+  xml_name "LinkedReleaseResourceReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/membership.rb
+++ b/lib/ddex/ern/v38/membership.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::Membership < Element
   include ROXML
 
 
-  xml_name "ns1:Membership"
+  xml_name "Membership"
 
       xml_accessor :organization, :as => DDEX::ERN::V38::PartyDescriptor, :from => "Organization", :required => true
       xml_accessor :membership_type, :from => "MembershipType", :required => true

--- a/lib/ddex/ern/v38/message_audit_trail.rb
+++ b/lib/ddex/ern/v38/message_audit_trail.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::MessageAuditTrail < Element
   include ROXML
 
 
-  xml_name "ns1:MessageAuditTrail"
+  xml_name "MessageAuditTrail"
 
       xml_accessor :message_audit_trail_events, :as => [DDEX::ERN::V38::MessageAuditTrailEvent], :from => "MessageAuditTrailEvent", :required => true
 

--- a/lib/ddex/ern/v38/message_audit_trail_event.rb
+++ b/lib/ddex/ern/v38/message_audit_trail_event.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::MessageAuditTrailEvent < Element
   include ROXML
 
 
-  xml_name "ns1:MessageAuditTrailEvent"
+  xml_name "MessageAuditTrailEvent"
 
       xml_accessor :messaging_party_descriptor, :as => DDEX::ERN::V38::MessagingParty, :from => "MessagingPartyDescriptor", :required => true
       xml_accessor :date_time, :as => DateTime, :from => "DateTime", :required => true

--- a/lib/ddex/ern/v38/message_header.rb
+++ b/lib/ddex/ern/v38/message_header.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::MessageHeader < Element
   include ROXML
 
 
-  xml_name "ns1:MessageHeader"
+  xml_name "MessageHeader"
 
       xml_accessor :message_thread_id, :from => "MessageThreadId", :required => false
       xml_accessor :message_id, :from => "MessageId", :required => true

--- a/lib/ddex/ern/v38/messaging_party.rb
+++ b/lib/ddex/ern/v38/messaging_party.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::MessagingParty < Element
   include ROXML
 
 
-  xml_name "ns1:MessagingParty"
+  xml_name "MessagingParty"
 
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => true
       xml_accessor :party_name, :as => DDEX::ERN::V38::PartyName, :from => "PartyName", :required => false

--- a/lib/ddex/ern/v38/midi.rb
+++ b/lib/ddex/ern/v38/midi.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V38::MIDI < Element
   include ROXML
 
 
-  xml_name "ns1:MIDI"
+  xml_name "MIDI"
 
       xml_accessor :midi_type, :as => DDEX::ERN::V38::MidiType, :from => "MidiType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/midi_details_by_territory.rb
+++ b/lib/ddex/ern/v38/midi_details_by_territory.rb
@@ -37,7 +37,7 @@ class DDEX::ERN::V38::MidiDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:MidiDetailsByTerritory"
+  xml_name "MidiDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/midi_type.rb
+++ b/lib/ddex/ern/v38/midi_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::MidiType < Element
   include ROXML
 
 
-  xml_name "ns1:MidiType"
+  xml_name "MidiType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/musical_work.rb
+++ b/lib/ddex/ern/v38/musical_work.rb
@@ -24,7 +24,7 @@ class DDEX::ERN::V38::MusicalWork < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWork"
+  xml_name "MusicalWork"
 
       xml_accessor :musical_work_ids, :as => [DDEX::ERN::V38::MusicalWorkId], :from => "MusicalWorkId", :required => true
       xml_accessor :musical_work_reference, :from => "MusicalWorkReference", :required => true

--- a/lib/ddex/ern/v38/musical_work_contributor.rb
+++ b/lib/ddex/ern/v38/musical_work_contributor.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::MusicalWorkContributor < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkContributor"
+  xml_name "MusicalWorkContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/musical_work_contributor_role.rb
+++ b/lib/ddex/ern/v38/musical_work_contributor_role.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::MusicalWorkContributorRole < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkContributorRole"
+  xml_name "MusicalWorkContributorRole"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/musical_work_details_by_territory.rb
+++ b/lib/ddex/ern/v38/musical_work_details_by_territory.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::MusicalWorkDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkDetailsByTerritory"
+  xml_name "MusicalWorkDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/musical_work_id.rb
+++ b/lib/ddex/ern/v38/musical_work_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::MusicalWorkId < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkId"
+  xml_name "MusicalWorkId"
 
       xml_accessor :iswc, :from => "ISWC", :required => false
       xml_accessor :opus_number, :from => "OpusNumber", :required => false

--- a/lib/ddex/ern/v38/musical_work_type.rb
+++ b/lib/ddex/ern/v38/musical_work_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::MusicalWorkType < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkType"
+  xml_name "MusicalWorkType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/name.rb
+++ b/lib/ddex/ern/v38/name.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Name < Element
   include ROXML
 
 
-  xml_name "ns1:Name"
+  xml_name "Name"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/new_release_message.rb
+++ b/lib/ddex/ern/v38/new_release_message.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V38::NewReleaseMessage < Element
 
     setns "ns1", "http://ddex.net/xml/ern/38"
 
-  xml_name "ns1:NewReleaseMessage"
+  xml_name "NewReleaseMessage"
 
       xml_accessor :message_header, :as => DDEX::ERN::V38::MessageHeader, :from => "MessageHeader", :required => true
       xml_accessor :update_indicator, :from => "UpdateIndicator", :required => false
@@ -40,19 +40,19 @@ class DDEX::ERN::V38::NewReleaseMessage < Element
       xml_accessor :deal_list, :as => DDEX::ERN::V38::DealList, :from => "DealList", :required => false
 
 
-  
+
       xml_accessor :message_schema_version_id, :from => "@MessageSchemaVersionId", :required => true
-    
-  
+
+
       xml_accessor :business_profile_version_id, :from => "@BusinessProfileVersionId", :required => false
-    
-  
+
+
       xml_accessor :release_profile_version_id, :from => "@ReleaseProfileVersionId", :required => false
-    
-  
+
+
       xml_accessor :language_and_script_code, :from => "@LanguageAndScriptCode", :required => false
-    
-  
+
+
 
 end
 

--- a/lib/ddex/ern/v38/operating_system_type.rb
+++ b/lib/ddex/ern/v38/operating_system_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::OperatingSystemType < Element
   include ROXML
 
 
-  xml_name "ns1:OperatingSystemType"
+  xml_name "OperatingSystemType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/p_line.rb
+++ b/lib/ddex/ern/v38/p_line.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::PLine < Element
   include ROXML
 
 
-  xml_name "ns1:PLine"
+  xml_name "PLine"
 
       xml_accessor :year, :from => "Year", :required => false
       xml_accessor :p_line_company, :from => "PLineCompany", :required => false

--- a/lib/ddex/ern/v38/parental_warning_type.rb
+++ b/lib/ddex/ern/v38/parental_warning_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ParentalWarningType < Element
   include ROXML
 
 
-  xml_name "ns1:ParentalWarningType"
+  xml_name "ParentalWarningType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/party_descriptor.rb
+++ b/lib/ddex/ern/v38/party_descriptor.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::PartyDescriptor < Element
   include ROXML
 
 
-  xml_name "ns1:PartyDescriptor"
+  xml_name "PartyDescriptor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/party_id.rb
+++ b/lib/ddex/ern/v38/party_id.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::PartyId < Element
   include ROXML
 
 
-  xml_name "ns1:PartyId"
+  xml_name "PartyId"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/party_name.rb
+++ b/lib/ddex/ern/v38/party_name.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::PartyName < Element
   include ROXML
 
 
-  xml_name "ns1:PartyName"
+  xml_name "PartyName"
 
       xml_accessor :full_name, :as => DDEX::ERN::V38::Name, :from => "FullName", :required => true
       xml_accessor :full_name_ascii_transcribed, :from => "FullNameAsciiTranscribed", :required => false

--- a/lib/ddex/ern/v38/percentage.rb
+++ b/lib/ddex/ern/v38/percentage.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Percentage < Element
   include ROXML
 
 
-  xml_name "ns1:Percentage"
+  xml_name "Percentage"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/performance.rb
+++ b/lib/ddex/ern/v38/performance.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::Performance < Element
   include ROXML
 
 
-  xml_name "ns1:Performance"
+  xml_name "Performance"
 
       xml_accessor :territory, :as => DDEX::ERN::V38::AllTerritoryCode, :from => "Territory", :required => false
       xml_accessor :date, :as => DDEX::ERN::V38::EventDate, :from => "Date", :required => false

--- a/lib/ddex/ern/v38/period.rb
+++ b/lib/ddex/ern/v38/period.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::Period < Element
   include ROXML
 
 
-  xml_name "ns1:Period"
+  xml_name "Period"
 
       xml_accessor :start_date_time, :as => DDEX::ERN::V38::EventDateTime, :from => "StartDateTime", :required => false
       xml_accessor :end_date_time, :as => DDEX::ERN::V38::EventDateTime, :from => "EndDateTime", :required => false

--- a/lib/ddex/ern/v38/physical_returns.rb
+++ b/lib/ddex/ern/v38/physical_returns.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::PhysicalReturns < Element
   include ROXML
 
 
-  xml_name "ns1:PhysicalReturns"
+  xml_name "PhysicalReturns"
 
       xml_accessor :physical_returns_allowed?, :from => "PhysicalReturnsAllowed", :required => false
       xml_accessor :latest_date_for_physical_returns, :from => "LatestDateForPhysicalReturns", :required => false

--- a/lib/ddex/ern/v38/preview_details.rb
+++ b/lib/ddex/ern/v38/preview_details.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::PreviewDetails < Element
   include ROXML
 
 
-  xml_name "ns1:PreviewDetails"
+  xml_name "PreviewDetails"
 
       xml_accessor :part_type, :as => DDEX::ERN::V38::Description, :from => "PartType", :required => false
       xml_accessor :top_left_corner, :as => Float, :from => "TopLeftCorner", :required => false

--- a/lib/ddex/ern/v38/price.rb
+++ b/lib/ddex/ern/v38/price.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Price < Element
   include ROXML
 
 
-  xml_name "ns1:Price"
+  xml_name "Price"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/price_information.rb
+++ b/lib/ddex/ern/v38/price_information.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::PriceInformation < Element
   include ROXML
 
 
-  xml_name "ns1:PriceInformation"
+  xml_name "PriceInformation"
 
       xml_accessor :description, :as => DDEX::ERN::V38::Description, :from => "Description", :required => false
       xml_accessor :price_range_type, :as => DDEX::ERN::V38::PriceRangeType, :from => "PriceRangeType", :required => false

--- a/lib/ddex/ern/v38/price_range_type.rb
+++ b/lib/ddex/ern/v38/price_range_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::PriceRangeType < Element
   include ROXML
 
 
-  xml_name "ns1:PriceRangeType"
+  xml_name "PriceRangeType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/price_type.rb
+++ b/lib/ddex/ern/v38/price_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::PriceType < Element
   include ROXML
 
 
-  xml_name "ns1:PriceType"
+  xml_name "PriceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/promotional_code.rb
+++ b/lib/ddex/ern/v38/promotional_code.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::PromotionalCode < Element
   include ROXML
 
 
-  xml_name "ns1:PromotionalCode"
+  xml_name "PromotionalCode"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/proprietary_id.rb
+++ b/lib/ddex/ern/v38/proprietary_id.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ProprietaryId < Element
   include ROXML
 
 
-  xml_name "ns1:ProprietaryId"
+  xml_name "ProprietaryId"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/purge_release_message.rb
+++ b/lib/ddex/ern/v38/purge_release_message.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::PurgeReleaseMessage < Element
 
     setns "ns1", "http://ddex.net/xml/ern/38"
 
-  xml_name "ns1:PurgeReleaseMessage"
+  xml_name "PurgeReleaseMessage"
 
       xml_accessor :message_header, :as => DDEX::ERN::V38::MessageHeader, :from => "MessageHeader", :required => true
       xml_accessor :purged_release, :as => DDEX::ERN::V38::PurgedRelease, :from => "PurgedRelease", :required => true

--- a/lib/ddex/ern/v38/purged_release.rb
+++ b/lib/ddex/ern/v38/purged_release.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::PurgedRelease < Element
   include ROXML
 
 
-  xml_name "ns1:PurgedRelease"
+  xml_name "PurgedRelease"
 
       xml_accessor :release_id, :as => DDEX::ERN::V38::ReleaseId, :from => "ReleaseId", :required => false
       xml_accessor :titles, :as => [DDEX::ERN::V38::Title], :from => "Title", :required => false

--- a/lib/ddex/ern/v38/purpose.rb
+++ b/lib/ddex/ern/v38/purpose.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Purpose < Element
   include ROXML
 
 
-  xml_name "ns1:Purpose"
+  xml_name "Purpose"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/rating_agency.rb
+++ b/lib/ddex/ern/v38/rating_agency.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::RatingAgency < Element
   include ROXML
 
 
-  xml_name "ns1:RatingAgency"
+  xml_name "RatingAgency"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/reason.rb
+++ b/lib/ddex/ern/v38/reason.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Reason < Element
   include ROXML
 
 
-  xml_name "ns1:Reason"
+  xml_name "Reason"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/reason_type.rb
+++ b/lib/ddex/ern/v38/reason_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ReasonType < Element
   include ROXML
 
 
-  xml_name "ns1:ReasonType"
+  xml_name "ReasonType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/reference_title.rb
+++ b/lib/ddex/ern/v38/reference_title.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::ReferenceTitle < Element
   include ROXML
 
 
-  xml_name "ns1:ReferenceTitle"
+  xml_name "ReferenceTitle"
 
       xml_accessor :title_text, :as => DDEX::ERN::V38::TitleText, :from => "TitleText", :required => true
       xml_accessor :sub_title, :as => DDEX::ERN::V38::SubTitle, :from => "SubTitle", :required => false

--- a/lib/ddex/ern/v38/related_release.rb
+++ b/lib/ddex/ern/v38/related_release.rb
@@ -23,7 +23,7 @@ class DDEX::ERN::V38::RelatedRelease < Element
   include ROXML
 
 
-  xml_name "ns1:RelatedRelease"
+  xml_name "RelatedRelease"
 
       xml_accessor :release_ids, :as => [DDEX::ERN::V38::ReleaseId], :from => "ReleaseId", :required => true
       xml_accessor :reference_title, :as => DDEX::ERN::V38::ReferenceTitle, :from => "ReferenceTitle", :required => false

--- a/lib/ddex/ern/v38/related_release_offer_set.rb
+++ b/lib/ddex/ern/v38/related_release_offer_set.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V38::RelatedReleaseOfferSet < Element
   include ROXML
 
 
-  xml_name "ns1:RelatedReleaseOfferSet"
+  xml_name "RelatedReleaseOfferSet"
 
       xml_accessor :release_description, :as => DDEX::ERN::V38::Description, :from => "ReleaseDescription", :required => false
       xml_accessor :release_ids, :as => [DDEX::ERN::V38::ReleaseId], :from => "ReleaseId", :required => false

--- a/lib/ddex/ern/v38/release.rb
+++ b/lib/ddex/ern/v38/release.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V38::Release < Element
   include ROXML
 
 
-  xml_name "ns1:Release"
+  xml_name "Release"
 
       xml_accessor :release_ids, :as => [DDEX::ERN::V38::ReleaseId], :from => "ReleaseId", :required => true
       xml_accessor :release_references, :as => [], :from => "ReleaseReference", :required => false

--- a/lib/ddex/ern/v38/release_collection_reference.rb
+++ b/lib/ddex/ern/v38/release_collection_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ReleaseCollectionReference < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseCollectionReference"
+  xml_name "ReleaseCollectionReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/release_collection_reference_list.rb
+++ b/lib/ddex/ern/v38/release_collection_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ReleaseCollectionReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseCollectionReferenceList"
+  xml_name "ReleaseCollectionReferenceList"
 
       xml_accessor :number_of_collections, :as => Integer, :from => "NumberOfCollections", :required => false
       xml_accessor :release_collection_references, :as => [DDEX::ERN::V38::ReleaseCollectionReference], :from => "ReleaseCollectionReference", :required => true

--- a/lib/ddex/ern/v38/release_deal.rb
+++ b/lib/ddex/ern/v38/release_deal.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ReleaseDeal < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseDeal"
+  xml_name "ReleaseDeal"
 
       xml_accessor :deal_release_references, :as => [], :from => "DealReleaseReference", :required => true
       xml_accessor :deals, :as => [DDEX::ERN::V38::Deal], :from => "Deal", :required => true

--- a/lib/ddex/ern/v38/release_details_by_territory.rb
+++ b/lib/ddex/ern/v38/release_details_by_territory.rb
@@ -39,7 +39,7 @@ class DDEX::ERN::V38::ReleaseDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseDetailsByTerritory"
+  xml_name "ReleaseDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/release_id.rb
+++ b/lib/ddex/ern/v38/release_id.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::ReleaseId < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseId"
+  xml_name "ReleaseId"
 
       xml_accessor :g_rid, :from => "GRid", :required => false
       xml_accessor :isrc, :from => "ISRC", :required => false

--- a/lib/ddex/ern/v38/release_list.rb
+++ b/lib/ddex/ern/v38/release_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ReleaseList < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseList"
+  xml_name "ReleaseList"
 
       xml_accessor :releases, :as => [DDEX::ERN::V38::Release], :from => "Release", :required => false
 

--- a/lib/ddex/ern/v38/release_relationship_type.rb
+++ b/lib/ddex/ern/v38/release_relationship_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ReleaseRelationshipType < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseRelationshipType"
+  xml_name "ReleaseRelationshipType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/release_resource_reference.rb
+++ b/lib/ddex/ern/v38/release_resource_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ReleaseResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseResourceReference"
+  xml_name "ReleaseResourceReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/release_resource_reference_list.rb
+++ b/lib/ddex/ern/v38/release_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ReleaseResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseResourceReferenceList"
+  xml_name "ReleaseResourceReferenceList"
 
       xml_accessor :release_resource_references, :as => [DDEX::ERN::V38::ReleaseResourceReference], :from => "ReleaseResourceReference", :required => true
 

--- a/lib/ddex/ern/v38/release_summary_details_by_territory.rb
+++ b/lib/ddex/ern/v38/release_summary_details_by_territory.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::ReleaseSummaryDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseSummaryDetailsByTerritory"
+  xml_name "ReleaseSummaryDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/release_type.rb
+++ b/lib/ddex/ern/v38/release_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ReleaseType < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseType"
+  xml_name "ReleaseType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/resource_contained_resource_reference.rb
+++ b/lib/ddex/ern/v38/resource_contained_resource_reference.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ResourceContainedResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContainedResourceReference"
+  xml_name "ResourceContainedResourceReference"
 
       xml_accessor :resource_contained_resource_reference, :from => "ResourceContainedResourceReference", :required => true
       xml_accessor :duration_used, :from => "DurationUsed", :required => false

--- a/lib/ddex/ern/v38/resource_contained_resource_reference_list.rb
+++ b/lib/ddex/ern/v38/resource_contained_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ResourceContainedResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContainedResourceReferenceList"
+  xml_name "ResourceContainedResourceReferenceList"
 
       xml_accessor :resource_contained_resource_references, :as => [DDEX::ERN::V38::ResourceContainedResourceReference], :from => "ResourceContainedResourceReference", :required => true
 

--- a/lib/ddex/ern/v38/resource_contributor.rb
+++ b/lib/ddex/ern/v38/resource_contributor.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::ResourceContributor < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContributor"
+  xml_name "ResourceContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/resource_contributor_role.rb
+++ b/lib/ddex/ern/v38/resource_contributor_role.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ResourceContributorRole < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContributorRole"
+  xml_name "ResourceContributorRole"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/resource_group.rb
+++ b/lib/ddex/ern/v38/resource_group.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V38::ResourceGroup < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceGroup"
+  xml_name "ResourceGroup"
 
       xml_accessor :titles, :as => [DDEX::ERN::V38::Title], :from => "Title", :required => false
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false

--- a/lib/ddex/ern/v38/resource_group_resource_reference_list.rb
+++ b/lib/ddex/ern/v38/resource_group_resource_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ResourceGroupResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceGroupResourceReferenceList"
+  xml_name "ResourceGroupResourceReferenceList"
 
       xml_accessor :resource_group_resource_references, :as => [], :from => "ResourceGroupResourceReference", :required => true
 

--- a/lib/ddex/ern/v38/resource_list.rb
+++ b/lib/ddex/ern/v38/resource_list.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V38::ResourceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceList"
+  xml_name "ResourceList"
 
       xml_accessor :sound_recordings, :as => [DDEX::ERN::V38::SoundRecording], :from => "SoundRecording", :required => false
       xml_accessor :midis, :as => [DDEX::ERN::V38::MIDI], :from => "MIDI", :required => false

--- a/lib/ddex/ern/v38/resource_musical_work_reference.rb
+++ b/lib/ddex/ern/v38/resource_musical_work_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ResourceMusicalWorkReference < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceMusicalWorkReference"
+  xml_name "ResourceMusicalWorkReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :duration_used, :from => "DurationUsed", :required => false

--- a/lib/ddex/ern/v38/resource_musical_work_reference_list.rb
+++ b/lib/ddex/ern/v38/resource_musical_work_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ResourceMusicalWorkReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceMusicalWorkReferenceList"
+  xml_name "ResourceMusicalWorkReferenceList"
 
       xml_accessor :resource_musical_work_references, :as => [DDEX::ERN::V38::ResourceMusicalWorkReference], :from => "ResourceMusicalWorkReference", :required => true
 

--- a/lib/ddex/ern/v38/resource_omission_reason.rb
+++ b/lib/ddex/ern/v38/resource_omission_reason.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ResourceOmissionReason < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceOmissionReason"
+  xml_name "ResourceOmissionReason"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/resource_proprietary_id.rb
+++ b/lib/ddex/ern/v38/resource_proprietary_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ResourceProprietaryId < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceProprietaryId"
+  xml_name "ResourceProprietaryId"
 
       xml_accessor :proprietary_ids, :as => [DDEX::ERN::V38::ProprietaryId], :from => "ProprietaryId", :required => true
 

--- a/lib/ddex/ern/v38/resource_type.rb
+++ b/lib/ddex/ern/v38/resource_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::ResourceType < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceType"
+  xml_name "ResourceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/resource_usage.rb
+++ b/lib/ddex/ern/v38/resource_usage.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::ResourceUsage < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceUsage"
+  xml_name "ResourceUsage"
 
       xml_accessor :deal_resource_references, :as => [], :from => "DealResourceReference", :required => false
       xml_accessor :usages, :as => [DDEX::ERN::V38::Usage], :from => "Usage", :required => true

--- a/lib/ddex/ern/v38/right_share.rb
+++ b/lib/ddex/ern/v38/right_share.rb
@@ -30,7 +30,7 @@ class DDEX::ERN::V38::RightShare < Element
   include ROXML
 
 
-  xml_name "ns1:RightShare"
+  xml_name "RightShare"
 
       xml_accessor :right_share_id, :as => DDEX::ERN::V38::RightsAgreementId, :from => "RightShareId", :required => false
       xml_accessor :right_share_reference, :from => "RightShareReference", :required => true

--- a/lib/ddex/ern/v38/right_share_creation_reference_list.rb
+++ b/lib/ddex/ern/v38/right_share_creation_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::RightShareCreationReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:RightShareCreationReferenceList"
+  xml_name "RightShareCreationReferenceList"
 
       xml_accessor :right_share_work_references, :as => [], :from => "RightShareWorkReference", :required => false
       xml_accessor :right_share_resource_references, :as => [], :from => "RightShareResourceReference", :required => false

--- a/lib/ddex/ern/v38/rights_agreement_id.rb
+++ b/lib/ddex/ern/v38/rights_agreement_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::RightsAgreementId < Element
   include ROXML
 
 
-  xml_name "ns1:RightsAgreementId"
+  xml_name "RightsAgreementId"
 
       xml_accessor :mwlis, :as => [], :from => "MWLI", :required => false
       xml_accessor :proprietary_ids, :as => [DDEX::ERN::V38::ProprietaryId], :from => "ProprietaryId", :required => false

--- a/lib/ddex/ern/v38/rights_claim_policy.rb
+++ b/lib/ddex/ern/v38/rights_claim_policy.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::RightsClaimPolicy < Element
   include ROXML
 
 
-  xml_name "ns1:RightsClaimPolicy"
+  xml_name "RightsClaimPolicy"
 
       xml_accessor :condition, :as => DDEX::ERN::V38::Condition, :from => "Condition", :required => true
       xml_accessor :rights_claim_policy_type, :from => "RightsClaimPolicyType", :required => true

--- a/lib/ddex/ern/v38/rights_controller.rb
+++ b/lib/ddex/ern/v38/rights_controller.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::RightsController < Element
   include ROXML
 
 
-  xml_name "ns1:RightsController"
+  xml_name "RightsController"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/rights_type.rb
+++ b/lib/ddex/ern/v38/rights_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::RightsType < Element
   include ROXML
 
 
-  xml_name "ns1:RightsType"
+  xml_name "RightsType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/sales_reporting_proxy_release_id.rb
+++ b/lib/ddex/ern/v38/sales_reporting_proxy_release_id.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::SalesReportingProxyReleaseId < Element
   include ROXML
 
 
-  xml_name "ns1:SalesReportingProxyReleaseId"
+  xml_name "SalesReportingProxyReleaseId"
 
       xml_accessor :release_id, :as => DDEX::ERN::V38::ReleaseId, :from => "ReleaseId", :required => true
       xml_accessor :reason, :as => DDEX::ERN::V38::Reason, :from => "Reason", :required => false

--- a/lib/ddex/ern/v38/sampling_rate.rb
+++ b/lib/ddex/ern/v38/sampling_rate.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SamplingRate < Element
   include ROXML
 
 
-  xml_name "ns1:SamplingRate"
+  xml_name "SamplingRate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/sheet_music.rb
+++ b/lib/ddex/ern/v38/sheet_music.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V38::SheetMusic < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusic"
+  xml_name "SheetMusic"
 
       xml_accessor :sheet_music_type, :as => DDEX::ERN::V38::SheetMusicType, :from => "SheetMusicType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/sheet_music_codec_type.rb
+++ b/lib/ddex/ern/v38/sheet_music_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SheetMusicCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicCodecType"
+  xml_name "SheetMusicCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/sheet_music_details_by_territory.rb
+++ b/lib/ddex/ern/v38/sheet_music_details_by_territory.rb
@@ -29,7 +29,7 @@ class DDEX::ERN::V38::SheetMusicDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicDetailsByTerritory"
+  xml_name "SheetMusicDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/sheet_music_id.rb
+++ b/lib/ddex/ern/v38/sheet_music_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::SheetMusicId < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicId"
+  xml_name "SheetMusicId"
 
       xml_accessor :ismn, :from => "ISMN", :required => false
       xml_accessor :proprietary_ids, :as => [DDEX::ERN::V38::ProprietaryId], :from => "ProprietaryId", :required => false

--- a/lib/ddex/ern/v38/sheet_music_type.rb
+++ b/lib/ddex/ern/v38/sheet_music_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SheetMusicType < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicType"
+  xml_name "SheetMusicType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/society_affiliation.rb
+++ b/lib/ddex/ern/v38/society_affiliation.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::SocietyAffiliation < Element
   include ROXML
 
 
-  xml_name "ns1:SocietyAffiliation"
+  xml_name "SocietyAffiliation"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/software.rb
+++ b/lib/ddex/ern/v38/software.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V38::Software < Element
   include ROXML
 
 
-  xml_name "ns1:Software"
+  xml_name "Software"
 
       xml_accessor :software_type, :as => DDEX::ERN::V38::SoftwareType, :from => "SoftwareType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/software_details_by_territory.rb
+++ b/lib/ddex/ern/v38/software_details_by_territory.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V38::SoftwareDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:SoftwareDetailsByTerritory"
+  xml_name "SoftwareDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/software_type.rb
+++ b/lib/ddex/ern/v38/software_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SoftwareType < Element
   include ROXML
 
 
-  xml_name "ns1:SoftwareType"
+  xml_name "SoftwareType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/sound_processor_type.rb
+++ b/lib/ddex/ern/v38/sound_processor_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SoundProcessorType < Element
   include ROXML
 
 
-  xml_name "ns1:SoundProcessorType"
+  xml_name "SoundProcessorType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/sound_recording.rb
+++ b/lib/ddex/ern/v38/sound_recording.rb
@@ -29,7 +29,7 @@ class DDEX::ERN::V38::SoundRecording < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecording"
+  xml_name "SoundRecording"
 
       xml_accessor :sound_recording_type, :as => DDEX::ERN::V38::SoundRecordingType, :from => "SoundRecordingType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/sound_recording_collection_reference.rb
+++ b/lib/ddex/ern/v38/sound_recording_collection_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SoundRecordingCollectionReference < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingCollectionReference"
+  xml_name "SoundRecordingCollectionReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :sound_recording_collection_reference, :from => "SoundRecordingCollectionReference", :required => true

--- a/lib/ddex/ern/v38/sound_recording_collection_reference_list.rb
+++ b/lib/ddex/ern/v38/sound_recording_collection_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::SoundRecordingCollectionReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingCollectionReferenceList"
+  xml_name "SoundRecordingCollectionReferenceList"
 
       xml_accessor :number_of_collections, :as => Integer, :from => "NumberOfCollections", :required => false
       xml_accessor :sound_recording_collection_references, :as => [DDEX::ERN::V38::SoundRecordingCollectionReference], :from => "SoundRecordingCollectionReference", :required => true

--- a/lib/ddex/ern/v38/sound_recording_details_by_territory.rb
+++ b/lib/ddex/ern/v38/sound_recording_details_by_territory.rb
@@ -38,7 +38,7 @@ class DDEX::ERN::V38::SoundRecordingDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingDetailsByTerritory"
+  xml_name "SoundRecordingDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/sound_recording_id.rb
+++ b/lib/ddex/ern/v38/sound_recording_id.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::SoundRecordingId < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingId"
+  xml_name "SoundRecordingId"
 
       xml_accessor :isrc, :from => "ISRC", :required => false
       xml_accessor :catalog_number, :as => DDEX::ERN::V38::CatalogNumber, :from => "CatalogNumber", :required => false

--- a/lib/ddex/ern/v38/sound_recording_preview_details.rb
+++ b/lib/ddex/ern/v38/sound_recording_preview_details.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::SoundRecordingPreviewDetails < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingPreviewDetails"
+  xml_name "SoundRecordingPreviewDetails"
 
       xml_accessor :part_type, :as => DDEX::ERN::V38::Description, :from => "PartType", :required => false
       xml_accessor :start_point, :as => Float, :from => "StartPoint", :required => false

--- a/lib/ddex/ern/v38/sound_recording_type.rb
+++ b/lib/ddex/ern/v38/sound_recording_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SoundRecordingType < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingType"
+  xml_name "SoundRecordingType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/sub_title.rb
+++ b/lib/ddex/ern/v38/sub_title.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::SubTitle < Element
   include ROXML
 
 
-  xml_name "ns1:SubTitle"
+  xml_name "SubTitle"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/synopsis.rb
+++ b/lib/ddex/ern/v38/synopsis.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::Synopsis < Element
   include ROXML
 
 
-  xml_name "ns1:Synopsis"
+  xml_name "Synopsis"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/tariff_reference.rb
+++ b/lib/ddex/ern/v38/tariff_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::TariffReference < Element
   include ROXML
 
 
-  xml_name "ns1:TariffReference"
+  xml_name "TariffReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/technical_image_details.rb
+++ b/lib/ddex/ern/v38/technical_image_details.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V38::TechnicalImageDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalImageDetails"
+  xml_name "TechnicalImageDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V38::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v38/technical_instantiation.rb
+++ b/lib/ddex/ern/v38/technical_instantiation.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::TechnicalInstantiation < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalInstantiation"
+  xml_name "TechnicalInstantiation"
 
       xml_accessor :drm_enforcement_type, :from => "DrmEnforcementType", :required => false
       xml_accessor :video_definition_type, :from => "VideoDefinitionType", :required => false

--- a/lib/ddex/ern/v38/technical_midi_details.rb
+++ b/lib/ddex/ern/v38/technical_midi_details.rb
@@ -23,7 +23,7 @@ class DDEX::ERN::V38::TechnicalMidiDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalMidiDetails"
+  xml_name "TechnicalMidiDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :duration, :from => "Duration", :required => false

--- a/lib/ddex/ern/v38/technical_sheet_music_details.rb
+++ b/lib/ddex/ern/v38/technical_sheet_music_details.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V38::TechnicalSheetMusicDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalSheetMusicDetails"
+  xml_name "TechnicalSheetMusicDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V38::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v38/technical_software_details.rb
+++ b/lib/ddex/ern/v38/technical_software_details.rb
@@ -24,7 +24,7 @@ class DDEX::ERN::V38::TechnicalSoftwareDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalSoftwareDetails"
+  xml_name "TechnicalSoftwareDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V38::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v38/technical_sound_recording_details.rb
+++ b/lib/ddex/ern/v38/technical_sound_recording_details.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V38::TechnicalSoundRecordingDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalSoundRecordingDetails"
+  xml_name "TechnicalSoundRecordingDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V38::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v38/technical_text_details.rb
+++ b/lib/ddex/ern/v38/technical_text_details.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V38::TechnicalTextDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalTextDetails"
+  xml_name "TechnicalTextDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V38::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v38/technical_user_defined_resource_details.rb
+++ b/lib/ddex/ern/v38/technical_user_defined_resource_details.rb
@@ -23,7 +23,7 @@ class DDEX::ERN::V38::TechnicalUserDefinedResourceDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalUserDefinedResourceDetails"
+  xml_name "TechnicalUserDefinedResourceDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :user_defined_values, :as => [DDEX::ERN::V38::UserDefinedValue], :from => "UserDefinedValue", :required => false

--- a/lib/ddex/ern/v38/technical_video_details.rb
+++ b/lib/ddex/ern/v38/technical_video_details.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V38::TechnicalVideoDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalVideoDetails"
+  xml_name "TechnicalVideoDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V38::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v38/text.rb
+++ b/lib/ddex/ern/v38/text.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V38::Text < Element
   include ROXML
 
 
-  xml_name "ns1:Text"
+  xml_name "Text"
 
       xml_accessor :text_type, :as => DDEX::ERN::V38::TextType, :from => "TextType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/text_codec_type.rb
+++ b/lib/ddex/ern/v38/text_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::TextCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:TextCodecType"
+  xml_name "TextCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/text_details_by_territory.rb
+++ b/lib/ddex/ern/v38/text_details_by_territory.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V38::TextDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:TextDetailsByTerritory"
+  xml_name "TextDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/text_id.rb
+++ b/lib/ddex/ern/v38/text_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::TextId < Element
   include ROXML
 
 
-  xml_name "ns1:TextId"
+  xml_name "TextId"
 
       xml_accessor :isbn, :from => "ISBN", :required => false
       xml_accessor :issn, :from => "ISSN", :required => false

--- a/lib/ddex/ern/v38/text_type.rb
+++ b/lib/ddex/ern/v38/text_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::TextType < Element
   include ROXML
 
 
-  xml_name "ns1:TextType"
+  xml_name "TextType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/title.rb
+++ b/lib/ddex/ern/v38/title.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::Title < Element
   include ROXML
 
 
-  xml_name "ns1:Title"
+  xml_name "Title"
 
       xml_accessor :title_text, :as => DDEX::ERN::V38::TitleText, :from => "TitleText", :required => true
       xml_accessor :sub_titles, :as => [DDEX::ERN::V38::TypedSubTitle], :from => "SubTitle", :required => false

--- a/lib/ddex/ern/v38/title_text.rb
+++ b/lib/ddex/ern/v38/title_text.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::TitleText < Element
   include ROXML
 
 
-  xml_name "ns1:TitleText"
+  xml_name "TitleText"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/typed_rights_controller.rb
+++ b/lib/ddex/ern/v38/typed_rights_controller.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V38::TypedRightsController < Element
   include ROXML
 
 
-  xml_name "ns1:TypedRightsController"
+  xml_name "TypedRightsController"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V38::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v38/typed_sub_title.rb
+++ b/lib/ddex/ern/v38/typed_sub_title.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::TypedSubTitle < Element
   include ROXML
 
 
-  xml_name "ns1:TypedSubTitle"
+  xml_name "TypedSubTitle"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/usage.rb
+++ b/lib/ddex/ern/v38/usage.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V38::Usage < Element
   include ROXML
 
 
-  xml_name "ns1:Usage"
+  xml_name "Usage"
 
       xml_accessor :use_types, :as => [DDEX::ERN::V38::UseType], :from => "UseType", :required => true
       xml_accessor :user_interface_types, :as => [DDEX::ERN::V38::UserInterfaceType], :from => "UserInterfaceType", :required => false

--- a/lib/ddex/ern/v38/use_type.rb
+++ b/lib/ddex/ern/v38/use_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::UseType < Element
   include ROXML
 
 
-  xml_name "ns1:UseType"
+  xml_name "UseType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/user_defined_resource.rb
+++ b/lib/ddex/ern/v38/user_defined_resource.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V38::UserDefinedResource < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedResource"
+  xml_name "UserDefinedResource"
 
       xml_accessor :user_defined_resource_type, :as => DDEX::ERN::V38::UserDefinedResourceType, :from => "UserDefinedResourceType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/user_defined_resource_details_by_territory.rb
+++ b/lib/ddex/ern/v38/user_defined_resource_details_by_territory.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V38::UserDefinedResourceDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedResourceDetailsByTerritory"
+  xml_name "UserDefinedResourceDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/user_defined_resource_type.rb
+++ b/lib/ddex/ern/v38/user_defined_resource_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::UserDefinedResourceType < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedResourceType"
+  xml_name "UserDefinedResourceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/user_defined_value.rb
+++ b/lib/ddex/ern/v38/user_defined_value.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::UserDefinedValue < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedValue"
+  xml_name "UserDefinedValue"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/user_interface_type.rb
+++ b/lib/ddex/ern/v38/user_interface_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::UserInterfaceType < Element
   include ROXML
 
 
-  xml_name "ns1:UserInterfaceType"
+  xml_name "UserInterfaceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/video.rb
+++ b/lib/ddex/ern/v38/video.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V38::Video < Element
   include ROXML
 
 
-  xml_name "ns1:Video"
+  xml_name "Video"
 
       xml_accessor :video_type, :as => DDEX::ERN::V38::VideoType, :from => "VideoType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v38/video_codec_type.rb
+++ b/lib/ddex/ern/v38/video_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::VideoCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:VideoCodecType"
+  xml_name "VideoCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/video_cue_sheet_reference.rb
+++ b/lib/ddex/ern/v38/video_cue_sheet_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::VideoCueSheetReference < Element
   include ROXML
 
 
-  xml_name "ns1:VideoCueSheetReference"
+  xml_name "VideoCueSheetReference"
 
       xml_accessor :video_cue_sheet_reference, :from => "VideoCueSheetReference", :required => true
 

--- a/lib/ddex/ern/v38/video_details_by_territory.rb
+++ b/lib/ddex/ern/v38/video_details_by_territory.rb
@@ -40,7 +40,7 @@ class DDEX::ERN::V38::VideoDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:VideoDetailsByTerritory"
+  xml_name "VideoDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V38::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v38/video_id.rb
+++ b/lib/ddex/ern/v38/video_id.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V38::VideoId < Element
   include ROXML
 
 
-  xml_name "ns1:VideoId"
+  xml_name "VideoId"
 
       xml_accessor :isrc, :from => "ISRC", :required => false
       xml_accessor :isan, :from => "ISAN", :required => false

--- a/lib/ddex/ern/v38/video_type.rb
+++ b/lib/ddex/ern/v38/video_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V38::VideoType < Element
   include ROXML
 
 
-  xml_name "ns1:VideoType"
+  xml_name "VideoType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v38/web_page.rb
+++ b/lib/ddex/ern/v38/web_page.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V38::WebPage < Element
   include ROXML
 
 
-  xml_name "ns1:WebPage"
+  xml_name "WebPage"
 
       xml_accessor :party_ids, :as => [DDEX::ERN::V38::PartyId], :from => "PartyId", :required => false
       xml_accessor :release_ids, :as => [DDEX::ERN::V38::ReleaseId], :from => "ReleaseId", :required => false

--- a/lib/ddex/ern/v38/web_policy.rb
+++ b/lib/ddex/ern/v38/web_policy.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::WebPolicy < Element
   include ROXML
 
 
-  xml_name "ns1:WebPolicy"
+  xml_name "WebPolicy"
 
       xml_accessor :condition, :as => DDEX::ERN::V38::Condition, :from => "Condition", :required => true
       xml_accessor :access_limitation, :from => "AccessLimitation", :required => false

--- a/lib/ddex/ern/v38/work_list.rb
+++ b/lib/ddex/ern/v38/work_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V38::WorkList < Element
   include ROXML
 
 
-  xml_name "ns1:WorkList"
+  xml_name "WorkList"
 
       xml_accessor :musical_works, :as => [DDEX::ERN::V38::MusicalWork], :from => "MusicalWork", :required => true
 

--- a/lib/ddex/ern/v381/administrating_record_company.rb
+++ b/lib/ddex/ern/v381/administrating_record_company.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::AdministratingRecordCompany < Element
   include ROXML
 
 
-  xml_name "ns1:AdministratingRecordCompany"
+  xml_name "AdministratingRecordCompany"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/all_territory_code.rb
+++ b/lib/ddex/ern/v381/all_territory_code.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::AllTerritoryCode < Element
   include ROXML
 
 
-  xml_name "ns1:AllTerritoryCode"
+  xml_name "AllTerritoryCode"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/artist.rb
+++ b/lib/ddex/ern/v381/artist.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::Artist < Element
   include ROXML
 
 
-  xml_name "ns1:Artist"
+  xml_name "Artist"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/artist_delegated_usage_rights.rb
+++ b/lib/ddex/ern/v381/artist_delegated_usage_rights.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::ArtistDelegatedUsageRights < Element
   include ROXML
 
 
-  xml_name "ns1:ArtistDelegatedUsageRights"
+  xml_name "ArtistDelegatedUsageRights"
 
       xml_accessor :use_types, :as => [DDEX::ERN::V381::UseType], :from => "UseType", :required => true
       xml_accessor :user_interface_types, :as => [DDEX::ERN::V381::UserInterfaceType], :from => "UserInterfaceType", :required => false

--- a/lib/ddex/ern/v381/artist_role.rb
+++ b/lib/ddex/ern/v381/artist_role.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ArtistRole < Element
   include ROXML
 
 
-  xml_name "ns1:ArtistRole"
+  xml_name "ArtistRole"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/aspect_ratio.rb
+++ b/lib/ddex/ern/v381/aspect_ratio.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::AspectRatio < Element
   include ROXML
 
 
-  xml_name "ns1:AspectRatio"
+  xml_name "AspectRatio"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/audio_codec_type.rb
+++ b/lib/ddex/ern/v381/audio_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::AudioCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:AudioCodecType"
+  xml_name "AudioCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/av_rating.rb
+++ b/lib/ddex/ern/v381/av_rating.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::AvRating < Element
   include ROXML
 
 
-  xml_name "ns1:AvRating"
+  xml_name "AvRating"
 
       xml_accessor :rating_text, :from => "RatingText", :required => true
       xml_accessor :rating_agency, :as => DDEX::ERN::V381::RatingAgency, :from => "RatingAgency", :required => true

--- a/lib/ddex/ern/v381/bit_rate.rb
+++ b/lib/ddex/ern/v381/bit_rate.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::BitRate < Element
   include ROXML
 
 
-  xml_name "ns1:BitRate"
+  xml_name "BitRate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/c_line.rb
+++ b/lib/ddex/ern/v381/c_line.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CLine < Element
   include ROXML
 
 
-  xml_name "ns1:CLine"
+  xml_name "CLine"
 
       xml_accessor :year, :from => "Year", :required => false
       xml_accessor :c_line_company, :from => "CLineCompany", :required => false

--- a/lib/ddex/ern/v381/carrier_type.rb
+++ b/lib/ddex/ern/v381/carrier_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CarrierType < Element
   include ROXML
 
 
-  xml_name "ns1:CarrierType"
+  xml_name "CarrierType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/catalog_item.rb
+++ b/lib/ddex/ern/v381/catalog_item.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V381::CatalogItem < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogItem"
+  xml_name "CatalogItem"
 
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::AllTerritoryCode], :from => "TerritoryCode", :required => true
       xml_accessor :release_ids, :as => [DDEX::ERN::V381::ReleaseId], :from => "ReleaseId", :required => true

--- a/lib/ddex/ern/v381/catalog_list_message.rb
+++ b/lib/ddex/ern/v381/catalog_list_message.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::CatalogListMessage < Element
 
     setns "ns1", "http://ddex.net/xml/ern/381"
 
-  xml_name "ns1:CatalogListMessage"
+  xml_name "CatalogListMessage"
 
       xml_accessor :message_header, :as => DDEX::ERN::V381::MessageHeader, :from => "MessageHeader", :required => true
       xml_accessor :publication_date, :as => DateTime, :from => "PublicationDate", :required => true

--- a/lib/ddex/ern/v381/catalog_number.rb
+++ b/lib/ddex/ern/v381/catalog_number.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CatalogNumber < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogNumber"
+  xml_name "CatalogNumber"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/catalog_release_reference_list.rb
+++ b/lib/ddex/ern/v381/catalog_release_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CatalogReleaseReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogReleaseReferenceList"
+  xml_name "CatalogReleaseReferenceList"
 
       xml_accessor :catalog_release_references, :as => [], :from => "CatalogReleaseReference", :required => true
 

--- a/lib/ddex/ern/v381/catalog_transfer.rb
+++ b/lib/ddex/ern/v381/catalog_transfer.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::CatalogTransfer < Element
   include ROXML
 
 
-  xml_name "ns1:CatalogTransfer"
+  xml_name "CatalogTransfer"
 
       xml_accessor :catalog_transfer_completed?, :from => "CatalogTransferCompleted", :required => false
       xml_accessor :effective_transfer_date, :as => DDEX::ERN::V381::EventDate, :from => "EffectiveTransferDate", :required => false

--- a/lib/ddex/ern/v381/character.rb
+++ b/lib/ddex/ern/v381/character.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::Character < Element
   include ROXML
 
 
-  xml_name "ns1:Character"
+  xml_name "Character"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/collection.rb
+++ b/lib/ddex/ern/v381/collection.rb
@@ -29,7 +29,7 @@ class DDEX::ERN::V381::Collection < Element
   include ROXML
 
 
-  xml_name "ns1:Collection"
+  xml_name "Collection"
 
       xml_accessor :collection_ids, :as => [DDEX::ERN::V381::CollectionId], :from => "CollectionId", :required => true
       xml_accessor :collection_types, :as => [DDEX::ERN::V381::CollectionType], :from => "CollectionType", :required => false

--- a/lib/ddex/ern/v381/collection_collection_reference.rb
+++ b/lib/ddex/ern/v381/collection_collection_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CollectionCollectionReference < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionCollectionReference"
+  xml_name "CollectionCollectionReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :collection_collection_reference, :from => "CollectionCollectionReference", :required => true

--- a/lib/ddex/ern/v381/collection_collection_reference_list.rb
+++ b/lib/ddex/ern/v381/collection_collection_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::CollectionCollectionReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionCollectionReferenceList"
+  xml_name "CollectionCollectionReferenceList"
 
       xml_accessor :number_of_collections, :as => Integer, :from => "NumberOfCollections", :required => false
       xml_accessor :collection_collection_references, :as => [DDEX::ERN::V381::CollectionCollectionReference], :from => "CollectionCollectionReference", :required => true

--- a/lib/ddex/ern/v381/collection_details_by_territory.rb
+++ b/lib/ddex/ern/v381/collection_details_by_territory.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::CollectionDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionDetailsByTerritory"
+  xml_name "CollectionDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/collection_id.rb
+++ b/lib/ddex/ern/v381/collection_id.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::CollectionId < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionId"
+  xml_name "CollectionId"
 
       xml_accessor :g_rid, :from => "GRid", :required => false
       xml_accessor :isrc, :from => "ISRC", :required => false

--- a/lib/ddex/ern/v381/collection_list.rb
+++ b/lib/ddex/ern/v381/collection_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::CollectionList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionList"
+  xml_name "CollectionList"
 
       xml_accessor :collections, :as => [DDEX::ERN::V381::Collection], :from => "Collection", :required => true
 

--- a/lib/ddex/ern/v381/collection_resource_reference.rb
+++ b/lib/ddex/ern/v381/collection_resource_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CollectionResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionResourceReference"
+  xml_name "CollectionResourceReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :collection_resource_reference, :from => "CollectionResourceReference", :required => true

--- a/lib/ddex/ern/v381/collection_resource_reference_list.rb
+++ b/lib/ddex/ern/v381/collection_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::CollectionResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionResourceReferenceList"
+  xml_name "CollectionResourceReferenceList"
 
       xml_accessor :collection_resource_references, :as => [DDEX::ERN::V381::CollectionResourceReference], :from => "CollectionResourceReference", :required => true
 

--- a/lib/ddex/ern/v381/collection_type.rb
+++ b/lib/ddex/ern/v381/collection_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CollectionType < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionType"
+  xml_name "CollectionType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/collection_work_reference.rb
+++ b/lib/ddex/ern/v381/collection_work_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CollectionWorkReference < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionWorkReference"
+  xml_name "CollectionWorkReference"
 
       xml_accessor :collection_work_reference, :from => "CollectionWorkReference", :required => true
       xml_accessor :duration, :from => "Duration", :required => false

--- a/lib/ddex/ern/v381/collection_work_reference_list.rb
+++ b/lib/ddex/ern/v381/collection_work_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::CollectionWorkReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:CollectionWorkReferenceList"
+  xml_name "CollectionWorkReferenceList"
 
       xml_accessor :collection_work_references, :as => [DDEX::ERN::V381::CollectionWorkReference], :from => "CollectionWorkReference", :required => true
 

--- a/lib/ddex/ern/v381/comment.rb
+++ b/lib/ddex/ern/v381/comment.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Comment < Element
   include ROXML
 
 
-  xml_name "ns1:Comment"
+  xml_name "Comment"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/commercial_model_type.rb
+++ b/lib/ddex/ern/v381/commercial_model_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CommercialModelType < Element
   include ROXML
 
 
-  xml_name "ns1:CommercialModelType"
+  xml_name "CommercialModelType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/condition.rb
+++ b/lib/ddex/ern/v381/condition.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Condition < Element
   include ROXML
 
 
-  xml_name "ns1:Condition"
+  xml_name "Condition"
 
       xml_accessor :value, :as => Float, :from => "Value", :required => true
       xml_accessor :unit, :from => "Unit", :required => true

--- a/lib/ddex/ern/v381/consumer_rental_period.rb
+++ b/lib/ddex/ern/v381/consumer_rental_period.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ConsumerRentalPeriod < Element
   include ROXML
 
 
-  xml_name "ns1:ConsumerRentalPeriod"
+  xml_name "ConsumerRentalPeriod"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/contact_id.rb
+++ b/lib/ddex/ern/v381/contact_id.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ContactId < Element
   include ROXML
 
 
-  xml_name "ns1:ContactId"
+  xml_name "ContactId"
 
       xml_accessor :email_addresses, :as => [], :from => "EmailAddress", :required => false
       xml_accessor :phone_numbers, :as => [], :from => "PhoneNumber", :required => false

--- a/lib/ddex/ern/v381/container_format.rb
+++ b/lib/ddex/ern/v381/container_format.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ContainerFormat < Element
   include ROXML
 
 
-  xml_name "ns1:ContainerFormat"
+  xml_name "ContainerFormat"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/courtesy_line.rb
+++ b/lib/ddex/ern/v381/courtesy_line.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CourtesyLine < Element
   include ROXML
 
 
-  xml_name "ns1:CourtesyLine"
+  xml_name "CourtesyLine"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/creation_id.rb
+++ b/lib/ddex/ern/v381/creation_id.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::CreationId < Element
   include ROXML
 
 
-  xml_name "ns1:CreationId"
+  xml_name "CreationId"
 
       xml_accessor :iswc, :from => "ISWC", :required => false
       xml_accessor :opus_number, :from => "OpusNumber", :required => false

--- a/lib/ddex/ern/v381/cue.rb
+++ b/lib/ddex/ern/v381/cue.rb
@@ -30,7 +30,7 @@ class DDEX::ERN::V381::Cue < Element
   include ROXML
 
 
-  xml_name "ns1:Cue"
+  xml_name "Cue"
 
       xml_accessor :cue_use_type, :as => DDEX::ERN::V381::CueUseType, :from => "CueUseType", :required => false
       xml_accessor :cue_theme_type, :as => DDEX::ERN::V381::CueThemeType, :from => "CueThemeType", :required => false

--- a/lib/ddex/ern/v381/cue_creation_reference.rb
+++ b/lib/ddex/ern/v381/cue_creation_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueCreationReference < Element
   include ROXML
 
 
-  xml_name "ns1:CueCreationReference"
+  xml_name "CueCreationReference"
 
       xml_accessor :cue_resource_reference, :from => "CueResourceReference", :required => false
       xml_accessor :cue_work_reference, :from => "CueWorkReference", :required => false

--- a/lib/ddex/ern/v381/cue_origin.rb
+++ b/lib/ddex/ern/v381/cue_origin.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueOrigin < Element
   include ROXML
 
 
-  xml_name "ns1:CueOrigin"
+  xml_name "CueOrigin"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/cue_sheet.rb
+++ b/lib/ddex/ern/v381/cue_sheet.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::CueSheet < Element
   include ROXML
 
 
-  xml_name "ns1:CueSheet"
+  xml_name "CueSheet"
 
       xml_accessor :cue_sheet_ids, :as => [DDEX::ERN::V381::ProprietaryId], :from => "CueSheetId", :required => false
       xml_accessor :cue_sheet_reference, :from => "CueSheetReference", :required => true

--- a/lib/ddex/ern/v381/cue_sheet_list.rb
+++ b/lib/ddex/ern/v381/cue_sheet_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::CueSheetList < Element
   include ROXML
 
 
-  xml_name "ns1:CueSheetList"
+  xml_name "CueSheetList"
 
       xml_accessor :cue_sheets, :as => [DDEX::ERN::V381::CueSheet], :from => "CueSheet", :required => true
 

--- a/lib/ddex/ern/v381/cue_sheet_type.rb
+++ b/lib/ddex/ern/v381/cue_sheet_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueSheetType < Element
   include ROXML
 
 
-  xml_name "ns1:CueSheetType"
+  xml_name "CueSheetType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/cue_theme_type.rb
+++ b/lib/ddex/ern/v381/cue_theme_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueThemeType < Element
   include ROXML
 
 
-  xml_name "ns1:CueThemeType"
+  xml_name "CueThemeType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/cue_use_type.rb
+++ b/lib/ddex/ern/v381/cue_use_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueUseType < Element
   include ROXML
 
 
-  xml_name "ns1:CueUseType"
+  xml_name "CueUseType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/cue_visual_perception_type.rb
+++ b/lib/ddex/ern/v381/cue_visual_perception_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueVisualPerceptionType < Element
   include ROXML
 
 
-  xml_name "ns1:CueVisualPerceptionType"
+  xml_name "CueVisualPerceptionType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/cue_vocal_type.rb
+++ b/lib/ddex/ern/v381/cue_vocal_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CueVocalType < Element
   include ROXML
 
 
-  xml_name "ns1:CueVocalType"
+  xml_name "CueVocalType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/current_territory_code.rb
+++ b/lib/ddex/ern/v381/current_territory_code.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::CurrentTerritoryCode < Element
   include ROXML
 
 
-  xml_name "ns1:CurrentTerritoryCode"
+  xml_name "CurrentTerritoryCode"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/deal.rb
+++ b/lib/ddex/ern/v381/deal.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V381::Deal < Element
   include ROXML
 
 
-  xml_name "ns1:Deal"
+  xml_name "Deal"
 
       xml_accessor :deal_references, :as => [DDEX::ERN::V381::DealReference], :from => "DealReference", :required => false
       xml_accessor :deal_terms, :as => DDEX::ERN::V381::DealTerms, :from => "DealTerms", :required => false

--- a/lib/ddex/ern/v381/deal_list.rb
+++ b/lib/ddex/ern/v381/deal_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::DealList < Element
   include ROXML
 
 
-  xml_name "ns1:DealList"
+  xml_name "DealList"
 
       xml_accessor :release_deals, :as => [DDEX::ERN::V381::ReleaseDeal], :from => "ReleaseDeal", :required => false
 

--- a/lib/ddex/ern/v381/deal_reference.rb
+++ b/lib/ddex/ern/v381/deal_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::DealReference < Element
   include ROXML
 
 
-  xml_name "ns1:DealReference"
+  xml_name "DealReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/deal_resource_reference_list.rb
+++ b/lib/ddex/ern/v381/deal_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::DealResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:DealResourceReferenceList"
+  xml_name "DealResourceReferenceList"
 
       xml_accessor :deal_resource_references, :as => [], :from => "DealResourceReference", :required => true
       xml_accessor :period, :as => DDEX::ERN::V381::Period, :from => "Period", :required => false

--- a/lib/ddex/ern/v381/deal_technical_resource_details_reference_list.rb
+++ b/lib/ddex/ern/v381/deal_technical_resource_details_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::DealTechnicalResourceDetailsReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:DealTechnicalResourceDetailsReferenceList"
+  xml_name "DealTechnicalResourceDetailsReferenceList"
 
       xml_accessor :deal_technical_resource_details_references, :as => [], :from => "DealTechnicalResourceDetailsReference", :required => true
 

--- a/lib/ddex/ern/v381/deal_terms.rb
+++ b/lib/ddex/ern/v381/deal_terms.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V381::DealTerms < Element
   include ROXML
 
 
-  xml_name "ns1:DealTerms"
+  xml_name "DealTerms"
 
       xml_accessor :pre_order_deal?, :from => "IsPreOrderDeal", :required => false
       xml_accessor :commercial_model_types, :as => [DDEX::ERN::V381::CommercialModelType], :from => "CommercialModelType", :required => false

--- a/lib/ddex/ern/v381/description.rb
+++ b/lib/ddex/ern/v381/description.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Description < Element
   include ROXML
 
 
-  xml_name "ns1:Description"
+  xml_name "Description"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/detailed_resource_contributor.rb
+++ b/lib/ddex/ern/v381/detailed_resource_contributor.rb
@@ -30,7 +30,7 @@ class DDEX::ERN::V381::DetailedResourceContributor < Element
   include ROXML
 
 
-  xml_name "ns1:DetailedResourceContributor"
+  xml_name "DetailedResourceContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/distribution_channel_type.rb
+++ b/lib/ddex/ern/v381/distribution_channel_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::DistributionChannelType < Element
   include ROXML
 
 
-  xml_name "ns1:DistributionChannelType"
+  xml_name "DistributionChannelType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/drm_platform_type.rb
+++ b/lib/ddex/ern/v381/drm_platform_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::DrmPlatformType < Element
   include ROXML
 
 
-  xml_name "ns1:DrmPlatformType"
+  xml_name "DrmPlatformType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/dsp.rb
+++ b/lib/ddex/ern/v381/dsp.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::DSP < Element
   include ROXML
 
 
-  xml_name "ns1:DSP"
+  xml_name "DSP"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/event_date.rb
+++ b/lib/ddex/ern/v381/event_date.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::EventDate < Element
   include ROXML
 
 
-  xml_name "ns1:EventDate"
+  xml_name "EventDate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/event_date_time.rb
+++ b/lib/ddex/ern/v381/event_date_time.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::EventDateTime < Element
   include ROXML
 
 
-  xml_name "ns1:EventDateTime"
+  xml_name "EventDateTime"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/extended_resource_group_content_item.rb
+++ b/lib/ddex/ern/v381/extended_resource_group_content_item.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::ExtendedResourceGroupContentItem < Element
   include ROXML
 
 
-  xml_name "ns1:ExtendedResourceGroupContentItem"
+  xml_name "ExtendedResourceGroupContentItem"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :sequence_sub_number, :as => Integer, :from => "SequenceSubNumber", :required => false

--- a/lib/ddex/ern/v381/extent.rb
+++ b/lib/ddex/ern/v381/extent.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Extent < Element
   include ROXML
 
 
-  xml_name "ns1:Extent"
+  xml_name "Extent"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/external_resource_link.rb
+++ b/lib/ddex/ern/v381/external_resource_link.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::ExternalResourceLink < Element
   include ROXML
 
 
-  xml_name "ns1:ExternalResourceLink"
+  xml_name "ExternalResourceLink"
 
       xml_accessor :urls, :as => [], :from => "URL", :required => true
       xml_accessor :validity_period, :as => DDEX::ERN::V381::Period, :from => "ValidityPeriod", :required => false

--- a/lib/ddex/ern/v381/externally_linked_resource_type.rb
+++ b/lib/ddex/ern/v381/externally_linked_resource_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ExternallyLinkedResourceType < Element
   include ROXML
 
 
-  xml_name "ns1:ExternallyLinkedResourceType"
+  xml_name "ExternallyLinkedResourceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/file.rb
+++ b/lib/ddex/ern/v381/file.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::File < Element
   include ROXML
 
 
-  xml_name "ns1:File"
+  xml_name "File"
 
       xml_accessor :url, :from => "URL", :required => false
       xml_accessor :file_name, :from => "FileName", :required => false

--- a/lib/ddex/ern/v381/fingerprint.rb
+++ b/lib/ddex/ern/v381/fingerprint.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::Fingerprint < Element
   include ROXML
 
 
-  xml_name "ns1:Fingerprint"
+  xml_name "Fingerprint"
 
       xml_accessor :fingerprint, :from => "Fingerprint", :required => true
       xml_accessor :fingerprint_algorithm_type, :as => DDEX::ERN::V381::FingerprintAlgorithmType, :from => "FingerprintAlgorithmType", :required => true

--- a/lib/ddex/ern/v381/fingerprint_algorithm_type.rb
+++ b/lib/ddex/ern/v381/fingerprint_algorithm_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::FingerprintAlgorithmType < Element
   include ROXML
 
 
-  xml_name "ns1:FingerprintAlgorithmType"
+  xml_name "FingerprintAlgorithmType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/frame_rate.rb
+++ b/lib/ddex/ern/v381/frame_rate.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::FrameRate < Element
   include ROXML
 
 
-  xml_name "ns1:FrameRate"
+  xml_name "FrameRate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/fulfillment_date.rb
+++ b/lib/ddex/ern/v381/fulfillment_date.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::FulfillmentDate < Element
   include ROXML
 
 
-  xml_name "ns1:FulfillmentDate"
+  xml_name "FulfillmentDate"
 
       xml_accessor :fulfillment_date, :from => "FulfillmentDate", :required => true
       xml_accessor :resource_release_references, :as => [], :from => "ResourceReleaseReference", :required => false

--- a/lib/ddex/ern/v381/genre.rb
+++ b/lib/ddex/ern/v381/genre.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::Genre < Element
   include ROXML
 
 
-  xml_name "ns1:Genre"
+  xml_name "Genre"
 
       xml_accessor :genre_text, :as => DDEX::ERN::V381::Description, :from => "GenreText", :required => true
       xml_accessor :sub_genre, :as => DDEX::ERN::V381::Description, :from => "SubGenre", :required => false

--- a/lib/ddex/ern/v381/governing_agreement_type.rb
+++ b/lib/ddex/ern/v381/governing_agreement_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::GoverningAgreementType < Element
   include ROXML
 
 
-  xml_name "ns1:GoverningAgreementType"
+  xml_name "GoverningAgreementType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/hash_sum.rb
+++ b/lib/ddex/ern/v381/hash_sum.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::HashSum < Element
   include ROXML
 
 
-  xml_name "ns1:HashSum"
+  xml_name "HashSum"
 
       xml_accessor :hash_sum, :from => "HashSum", :required => true
       xml_accessor :hash_sum_algorithm_type, :as => DDEX::ERN::V381::HashSumAlgorithmType, :from => "HashSumAlgorithmType", :required => true

--- a/lib/ddex/ern/v381/hash_sum_algorithm_type.rb
+++ b/lib/ddex/ern/v381/hash_sum_algorithm_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::HashSumAlgorithmType < Element
   include ROXML
 
 
-  xml_name "ns1:HashSumAlgorithmType"
+  xml_name "HashSumAlgorithmType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/host_sound_carrier.rb
+++ b/lib/ddex/ern/v381/host_sound_carrier.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V381::HostSoundCarrier < Element
   include ROXML
 
 
-  xml_name "ns1:HostSoundCarrier"
+  xml_name "HostSoundCarrier"
 
       xml_accessor :release_ids, :as => [DDEX::ERN::V381::ReleaseId], :from => "ReleaseId", :required => false
       xml_accessor :rights_agreement_id, :as => DDEX::ERN::V381::RightsAgreementId, :from => "RightsAgreementId", :required => false

--- a/lib/ddex/ern/v381/icpn.rb
+++ b/lib/ddex/ern/v381/icpn.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ICPN < Element
   include ROXML
 
 
-  xml_name "ns1:ICPN"
+  xml_name "ICPN"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/image.rb
+++ b/lib/ddex/ern/v381/image.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V381::Image < Element
   include ROXML
 
 
-  xml_name "ns1:Image"
+  xml_name "Image"
 
       xml_accessor :image_type, :as => DDEX::ERN::V381::ImageType, :from => "ImageType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/image_codec_type.rb
+++ b/lib/ddex/ern/v381/image_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ImageCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:ImageCodecType"
+  xml_name "ImageCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/image_details_by_territory.rb
+++ b/lib/ddex/ern/v381/image_details_by_territory.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V381::ImageDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:ImageDetailsByTerritory"
+  xml_name "ImageDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/image_type.rb
+++ b/lib/ddex/ern/v381/image_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ImageType < Element
   include ROXML
 
 
-  xml_name "ns1:ImageType"
+  xml_name "ImageType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/indirect_resource_contributor.rb
+++ b/lib/ddex/ern/v381/indirect_resource_contributor.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::IndirectResourceContributor < Element
   include ROXML
 
 
-  xml_name "ns1:IndirectResourceContributor"
+  xml_name "IndirectResourceContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/keywords.rb
+++ b/lib/ddex/ern/v381/keywords.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Keywords < Element
   include ROXML
 
 
-  xml_name "ns1:Keywords"
+  xml_name "Keywords"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/label_name.rb
+++ b/lib/ddex/ern/v381/label_name.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::LabelName < Element
   include ROXML
 
 
-  xml_name "ns1:LabelName"
+  xml_name "LabelName"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/linked_release_resource_reference.rb
+++ b/lib/ddex/ern/v381/linked_release_resource_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::LinkedReleaseResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:LinkedReleaseResourceReference"
+  xml_name "LinkedReleaseResourceReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/membership.rb
+++ b/lib/ddex/ern/v381/membership.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::Membership < Element
   include ROXML
 
 
-  xml_name "ns1:Membership"
+  xml_name "Membership"
 
       xml_accessor :organization, :as => DDEX::ERN::V381::PartyDescriptor, :from => "Organization", :required => true
       xml_accessor :membership_type, :from => "MembershipType", :required => true

--- a/lib/ddex/ern/v381/message_audit_trail.rb
+++ b/lib/ddex/ern/v381/message_audit_trail.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::MessageAuditTrail < Element
   include ROXML
 
 
-  xml_name "ns1:MessageAuditTrail"
+  xml_name "MessageAuditTrail"
 
       xml_accessor :message_audit_trail_events, :as => [DDEX::ERN::V381::MessageAuditTrailEvent], :from => "MessageAuditTrailEvent", :required => true
 

--- a/lib/ddex/ern/v381/message_audit_trail_event.rb
+++ b/lib/ddex/ern/v381/message_audit_trail_event.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::MessageAuditTrailEvent < Element
   include ROXML
 
 
-  xml_name "ns1:MessageAuditTrailEvent"
+  xml_name "MessageAuditTrailEvent"
 
       xml_accessor :messaging_party_descriptor, :as => DDEX::ERN::V381::MessagingParty, :from => "MessagingPartyDescriptor", :required => true
       xml_accessor :date_time, :as => DateTime, :from => "DateTime", :required => true

--- a/lib/ddex/ern/v381/message_header.rb
+++ b/lib/ddex/ern/v381/message_header.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::MessageHeader < Element
   include ROXML
 
 
-  xml_name "ns1:MessageHeader"
+  xml_name "MessageHeader"
 
       xml_accessor :message_thread_id, :from => "MessageThreadId", :required => false
       xml_accessor :message_id, :from => "MessageId", :required => true

--- a/lib/ddex/ern/v381/messaging_party.rb
+++ b/lib/ddex/ern/v381/messaging_party.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::MessagingParty < Element
   include ROXML
 
 
-  xml_name "ns1:MessagingParty"
+  xml_name "MessagingParty"
 
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => true
       xml_accessor :party_name, :as => DDEX::ERN::V381::PartyName, :from => "PartyName", :required => false

--- a/lib/ddex/ern/v381/midi.rb
+++ b/lib/ddex/ern/v381/midi.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V381::MIDI < Element
   include ROXML
 
 
-  xml_name "ns1:MIDI"
+  xml_name "MIDI"
 
       xml_accessor :midi_type, :as => DDEX::ERN::V381::MidiType, :from => "MidiType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/midi_details_by_territory.rb
+++ b/lib/ddex/ern/v381/midi_details_by_territory.rb
@@ -37,7 +37,7 @@ class DDEX::ERN::V381::MidiDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:MidiDetailsByTerritory"
+  xml_name "MidiDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/midi_type.rb
+++ b/lib/ddex/ern/v381/midi_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::MidiType < Element
   include ROXML
 
 
-  xml_name "ns1:MidiType"
+  xml_name "MidiType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/musical_work.rb
+++ b/lib/ddex/ern/v381/musical_work.rb
@@ -24,7 +24,7 @@ class DDEX::ERN::V381::MusicalWork < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWork"
+  xml_name "MusicalWork"
 
       xml_accessor :musical_work_ids, :as => [DDEX::ERN::V381::MusicalWorkId], :from => "MusicalWorkId", :required => true
       xml_accessor :musical_work_reference, :from => "MusicalWorkReference", :required => true

--- a/lib/ddex/ern/v381/musical_work_contributor.rb
+++ b/lib/ddex/ern/v381/musical_work_contributor.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::MusicalWorkContributor < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkContributor"
+  xml_name "MusicalWorkContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/musical_work_contributor_role.rb
+++ b/lib/ddex/ern/v381/musical_work_contributor_role.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::MusicalWorkContributorRole < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkContributorRole"
+  xml_name "MusicalWorkContributorRole"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/musical_work_details_by_territory.rb
+++ b/lib/ddex/ern/v381/musical_work_details_by_territory.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::MusicalWorkDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkDetailsByTerritory"
+  xml_name "MusicalWorkDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/musical_work_id.rb
+++ b/lib/ddex/ern/v381/musical_work_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::MusicalWorkId < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkId"
+  xml_name "MusicalWorkId"
 
       xml_accessor :iswc, :from => "ISWC", :required => false
       xml_accessor :opus_number, :from => "OpusNumber", :required => false

--- a/lib/ddex/ern/v381/musical_work_type.rb
+++ b/lib/ddex/ern/v381/musical_work_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::MusicalWorkType < Element
   include ROXML
 
 
-  xml_name "ns1:MusicalWorkType"
+  xml_name "MusicalWorkType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/name.rb
+++ b/lib/ddex/ern/v381/name.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Name < Element
   include ROXML
 
 
-  xml_name "ns1:Name"
+  xml_name "Name"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/new_release_message.rb
+++ b/lib/ddex/ern/v381/new_release_message.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V381::NewReleaseMessage < Element
 
     setns "ns1", "http://ddex.net/xml/ern/381"
 
-  xml_name "ns1:NewReleaseMessage"
+  xml_name "NewReleaseMessage"
 
       xml_accessor :message_header, :as => DDEX::ERN::V381::MessageHeader, :from => "MessageHeader", :required => true
       xml_accessor :update_indicator, :from => "UpdateIndicator", :required => false
@@ -40,19 +40,19 @@ class DDEX::ERN::V381::NewReleaseMessage < Element
       xml_accessor :deal_list, :as => DDEX::ERN::V381::DealList, :from => "DealList", :required => false
 
 
-  
+
       xml_accessor :message_schema_version_id, :from => "@MessageSchemaVersionId", :required => true
-    
-  
+
+
       xml_accessor :business_profile_version_id, :from => "@BusinessProfileVersionId", :required => false
-    
-  
+
+
       xml_accessor :release_profile_version_id, :from => "@ReleaseProfileVersionId", :required => false
-    
-  
+
+
       xml_accessor :language_and_script_code, :from => "@LanguageAndScriptCode", :required => false
-    
-  
+
+
 
 end
 

--- a/lib/ddex/ern/v381/operating_system_type.rb
+++ b/lib/ddex/ern/v381/operating_system_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::OperatingSystemType < Element
   include ROXML
 
 
-  xml_name "ns1:OperatingSystemType"
+  xml_name "OperatingSystemType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/p_line.rb
+++ b/lib/ddex/ern/v381/p_line.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::PLine < Element
   include ROXML
 
 
-  xml_name "ns1:PLine"
+  xml_name "PLine"
 
       xml_accessor :year, :from => "Year", :required => false
       xml_accessor :p_line_company, :from => "PLineCompany", :required => false

--- a/lib/ddex/ern/v381/parental_warning_type.rb
+++ b/lib/ddex/ern/v381/parental_warning_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ParentalWarningType < Element
   include ROXML
 
 
-  xml_name "ns1:ParentalWarningType"
+  xml_name "ParentalWarningType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/party_descriptor.rb
+++ b/lib/ddex/ern/v381/party_descriptor.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::PartyDescriptor < Element
   include ROXML
 
 
-  xml_name "ns1:PartyDescriptor"
+  xml_name "PartyDescriptor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/party_id.rb
+++ b/lib/ddex/ern/v381/party_id.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::PartyId < Element
   include ROXML
 
 
-  xml_name "ns1:PartyId"
+  xml_name "PartyId"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/party_name.rb
+++ b/lib/ddex/ern/v381/party_name.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::PartyName < Element
   include ROXML
 
 
-  xml_name "ns1:PartyName"
+  xml_name "PartyName"
 
       xml_accessor :full_name, :as => DDEX::ERN::V381::Name, :from => "FullName", :required => true
       xml_accessor :full_name_ascii_transcribed, :from => "FullNameAsciiTranscribed", :required => false

--- a/lib/ddex/ern/v381/percentage.rb
+++ b/lib/ddex/ern/v381/percentage.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Percentage < Element
   include ROXML
 
 
-  xml_name "ns1:Percentage"
+  xml_name "Percentage"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/performance.rb
+++ b/lib/ddex/ern/v381/performance.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::Performance < Element
   include ROXML
 
 
-  xml_name "ns1:Performance"
+  xml_name "Performance"
 
       xml_accessor :territory, :as => DDEX::ERN::V381::AllTerritoryCode, :from => "Territory", :required => false
       xml_accessor :date, :as => DDEX::ERN::V381::EventDate, :from => "Date", :required => false

--- a/lib/ddex/ern/v381/period.rb
+++ b/lib/ddex/ern/v381/period.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::Period < Element
   include ROXML
 
 
-  xml_name "ns1:Period"
+  xml_name "Period"
 
       xml_accessor :start_date_time, :as => DDEX::ERN::V381::EventDateTime, :from => "StartDateTime", :required => false
       xml_accessor :end_date_time, :as => DDEX::ERN::V381::EventDateTime, :from => "EndDateTime", :required => false

--- a/lib/ddex/ern/v381/physical_returns.rb
+++ b/lib/ddex/ern/v381/physical_returns.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::PhysicalReturns < Element
   include ROXML
 
 
-  xml_name "ns1:PhysicalReturns"
+  xml_name "PhysicalReturns"
 
       xml_accessor :physical_returns_allowed?, :from => "PhysicalReturnsAllowed", :required => false
       xml_accessor :latest_date_for_physical_returns, :from => "LatestDateForPhysicalReturns", :required => false

--- a/lib/ddex/ern/v381/preview_details.rb
+++ b/lib/ddex/ern/v381/preview_details.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::PreviewDetails < Element
   include ROXML
 
 
-  xml_name "ns1:PreviewDetails"
+  xml_name "PreviewDetails"
 
       xml_accessor :part_type, :as => DDEX::ERN::V381::Description, :from => "PartType", :required => false
       xml_accessor :top_left_corner, :as => Float, :from => "TopLeftCorner", :required => false

--- a/lib/ddex/ern/v381/price.rb
+++ b/lib/ddex/ern/v381/price.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Price < Element
   include ROXML
 
 
-  xml_name "ns1:Price"
+  xml_name "Price"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/price_information.rb
+++ b/lib/ddex/ern/v381/price_information.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::PriceInformation < Element
   include ROXML
 
 
-  xml_name "ns1:PriceInformation"
+  xml_name "PriceInformation"
 
       xml_accessor :description, :as => DDEX::ERN::V381::Description, :from => "Description", :required => false
       xml_accessor :price_range_type, :as => DDEX::ERN::V381::PriceRangeType, :from => "PriceRangeType", :required => false

--- a/lib/ddex/ern/v381/price_range_type.rb
+++ b/lib/ddex/ern/v381/price_range_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::PriceRangeType < Element
   include ROXML
 
 
-  xml_name "ns1:PriceRangeType"
+  xml_name "PriceRangeType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/price_type.rb
+++ b/lib/ddex/ern/v381/price_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::PriceType < Element
   include ROXML
 
 
-  xml_name "ns1:PriceType"
+  xml_name "PriceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/promotional_code.rb
+++ b/lib/ddex/ern/v381/promotional_code.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::PromotionalCode < Element
   include ROXML
 
 
-  xml_name "ns1:PromotionalCode"
+  xml_name "PromotionalCode"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/proprietary_id.rb
+++ b/lib/ddex/ern/v381/proprietary_id.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ProprietaryId < Element
   include ROXML
 
 
-  xml_name "ns1:ProprietaryId"
+  xml_name "ProprietaryId"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/purge_release_message.rb
+++ b/lib/ddex/ern/v381/purge_release_message.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::PurgeReleaseMessage < Element
 
     setns "ns1", "http://ddex.net/xml/ern/381"
 
-  xml_name "ns1:PurgeReleaseMessage"
+  xml_name "PurgeReleaseMessage"
 
       xml_accessor :message_header, :as => DDEX::ERN::V381::MessageHeader, :from => "MessageHeader", :required => true
       xml_accessor :purged_release, :as => DDEX::ERN::V381::PurgedRelease, :from => "PurgedRelease", :required => true

--- a/lib/ddex/ern/v381/purged_release.rb
+++ b/lib/ddex/ern/v381/purged_release.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::PurgedRelease < Element
   include ROXML
 
 
-  xml_name "ns1:PurgedRelease"
+  xml_name "PurgedRelease"
 
       xml_accessor :release_id, :as => DDEX::ERN::V381::ReleaseId, :from => "ReleaseId", :required => false
       xml_accessor :titles, :as => [DDEX::ERN::V381::Title], :from => "Title", :required => false

--- a/lib/ddex/ern/v381/purpose.rb
+++ b/lib/ddex/ern/v381/purpose.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Purpose < Element
   include ROXML
 
 
-  xml_name "ns1:Purpose"
+  xml_name "Purpose"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/rating_agency.rb
+++ b/lib/ddex/ern/v381/rating_agency.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::RatingAgency < Element
   include ROXML
 
 
-  xml_name "ns1:RatingAgency"
+  xml_name "RatingAgency"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/reason.rb
+++ b/lib/ddex/ern/v381/reason.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Reason < Element
   include ROXML
 
 
-  xml_name "ns1:Reason"
+  xml_name "Reason"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/reason_type.rb
+++ b/lib/ddex/ern/v381/reason_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ReasonType < Element
   include ROXML
 
 
-  xml_name "ns1:ReasonType"
+  xml_name "ReasonType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/reference_title.rb
+++ b/lib/ddex/ern/v381/reference_title.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::ReferenceTitle < Element
   include ROXML
 
 
-  xml_name "ns1:ReferenceTitle"
+  xml_name "ReferenceTitle"
 
       xml_accessor :title_text, :as => DDEX::ERN::V381::TitleText, :from => "TitleText", :required => true
       xml_accessor :sub_title, :as => DDEX::ERN::V381::SubTitle, :from => "SubTitle", :required => false

--- a/lib/ddex/ern/v381/related_release.rb
+++ b/lib/ddex/ern/v381/related_release.rb
@@ -23,7 +23,7 @@ class DDEX::ERN::V381::RelatedRelease < Element
   include ROXML
 
 
-  xml_name "ns1:RelatedRelease"
+  xml_name "RelatedRelease"
 
       xml_accessor :release_ids, :as => [DDEX::ERN::V381::ReleaseId], :from => "ReleaseId", :required => true
       xml_accessor :reference_title, :as => DDEX::ERN::V381::ReferenceTitle, :from => "ReferenceTitle", :required => false

--- a/lib/ddex/ern/v381/related_release_offer_set.rb
+++ b/lib/ddex/ern/v381/related_release_offer_set.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V381::RelatedReleaseOfferSet < Element
   include ROXML
 
 
-  xml_name "ns1:RelatedReleaseOfferSet"
+  xml_name "RelatedReleaseOfferSet"
 
       xml_accessor :release_description, :as => DDEX::ERN::V381::Description, :from => "ReleaseDescription", :required => false
       xml_accessor :release_ids, :as => [DDEX::ERN::V381::ReleaseId], :from => "ReleaseId", :required => false

--- a/lib/ddex/ern/v381/release.rb
+++ b/lib/ddex/ern/v381/release.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V381::Release < Element
   include ROXML
 
 
-  xml_name "ns1:Release"
+  xml_name "Release"
 
       xml_accessor :release_ids, :as => [DDEX::ERN::V381::ReleaseId], :from => "ReleaseId", :required => true
       xml_accessor :release_references, :as => [], :from => "ReleaseReference", :required => false

--- a/lib/ddex/ern/v381/release_collection_reference.rb
+++ b/lib/ddex/ern/v381/release_collection_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ReleaseCollectionReference < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseCollectionReference"
+  xml_name "ReleaseCollectionReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/release_collection_reference_list.rb
+++ b/lib/ddex/ern/v381/release_collection_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ReleaseCollectionReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseCollectionReferenceList"
+  xml_name "ReleaseCollectionReferenceList"
 
       xml_accessor :number_of_collections, :as => Integer, :from => "NumberOfCollections", :required => false
       xml_accessor :release_collection_references, :as => [DDEX::ERN::V381::ReleaseCollectionReference], :from => "ReleaseCollectionReference", :required => true

--- a/lib/ddex/ern/v381/release_deal.rb
+++ b/lib/ddex/ern/v381/release_deal.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ReleaseDeal < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseDeal"
+  xml_name "ReleaseDeal"
 
       xml_accessor :deal_release_references, :as => [], :from => "DealReleaseReference", :required => true
       xml_accessor :deals, :as => [DDEX::ERN::V381::Deal], :from => "Deal", :required => true

--- a/lib/ddex/ern/v381/release_details_by_territory.rb
+++ b/lib/ddex/ern/v381/release_details_by_territory.rb
@@ -39,7 +39,7 @@ class DDEX::ERN::V381::ReleaseDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseDetailsByTerritory"
+  xml_name "ReleaseDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/release_id.rb
+++ b/lib/ddex/ern/v381/release_id.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::ReleaseId < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseId"
+  xml_name "ReleaseId"
 
       xml_accessor :g_rid, :from => "GRid", :required => false
       xml_accessor :isrc, :from => "ISRC", :required => false

--- a/lib/ddex/ern/v381/release_list.rb
+++ b/lib/ddex/ern/v381/release_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ReleaseList < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseList"
+  xml_name "ReleaseList"
 
       xml_accessor :releases, :as => [DDEX::ERN::V381::Release], :from => "Release", :required => false
 

--- a/lib/ddex/ern/v381/release_relationship_type.rb
+++ b/lib/ddex/ern/v381/release_relationship_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ReleaseRelationshipType < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseRelationshipType"
+  xml_name "ReleaseRelationshipType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/release_resource_reference.rb
+++ b/lib/ddex/ern/v381/release_resource_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ReleaseResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseResourceReference"
+  xml_name "ReleaseResourceReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/release_resource_reference_list.rb
+++ b/lib/ddex/ern/v381/release_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ReleaseResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseResourceReferenceList"
+  xml_name "ReleaseResourceReferenceList"
 
       xml_accessor :release_resource_references, :as => [DDEX::ERN::V381::ReleaseResourceReference], :from => "ReleaseResourceReference", :required => true
 

--- a/lib/ddex/ern/v381/release_summary_details_by_territory.rb
+++ b/lib/ddex/ern/v381/release_summary_details_by_territory.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::ReleaseSummaryDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseSummaryDetailsByTerritory"
+  xml_name "ReleaseSummaryDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/release_type.rb
+++ b/lib/ddex/ern/v381/release_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ReleaseType < Element
   include ROXML
 
 
-  xml_name "ns1:ReleaseType"
+  xml_name "ReleaseType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/resource_contained_resource_reference.rb
+++ b/lib/ddex/ern/v381/resource_contained_resource_reference.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ResourceContainedResourceReference < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContainedResourceReference"
+  xml_name "ResourceContainedResourceReference"
 
       xml_accessor :resource_contained_resource_reference, :from => "ResourceContainedResourceReference", :required => true
       xml_accessor :duration_used, :from => "DurationUsed", :required => false

--- a/lib/ddex/ern/v381/resource_contained_resource_reference_list.rb
+++ b/lib/ddex/ern/v381/resource_contained_resource_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ResourceContainedResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContainedResourceReferenceList"
+  xml_name "ResourceContainedResourceReferenceList"
 
       xml_accessor :resource_contained_resource_references, :as => [DDEX::ERN::V381::ResourceContainedResourceReference], :from => "ResourceContainedResourceReference", :required => true
 

--- a/lib/ddex/ern/v381/resource_contributor.rb
+++ b/lib/ddex/ern/v381/resource_contributor.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::ResourceContributor < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContributor"
+  xml_name "ResourceContributor"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/resource_contributor_role.rb
+++ b/lib/ddex/ern/v381/resource_contributor_role.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ResourceContributorRole < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceContributorRole"
+  xml_name "ResourceContributorRole"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/resource_group.rb
+++ b/lib/ddex/ern/v381/resource_group.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V381::ResourceGroup < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceGroup"
+  xml_name "ResourceGroup"
 
       xml_accessor :titles, :as => [DDEX::ERN::V381::Title], :from => "Title", :required => false
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false

--- a/lib/ddex/ern/v381/resource_group_resource_reference_list.rb
+++ b/lib/ddex/ern/v381/resource_group_resource_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ResourceGroupResourceReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceGroupResourceReferenceList"
+  xml_name "ResourceGroupResourceReferenceList"
 
       xml_accessor :resource_group_resource_references, :as => [], :from => "ResourceGroupResourceReference", :required => true
 

--- a/lib/ddex/ern/v381/resource_list.rb
+++ b/lib/ddex/ern/v381/resource_list.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V381::ResourceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceList"
+  xml_name "ResourceList"
 
       xml_accessor :sound_recordings, :as => [DDEX::ERN::V381::SoundRecording], :from => "SoundRecording", :required => false
       xml_accessor :midis, :as => [DDEX::ERN::V381::MIDI], :from => "MIDI", :required => false

--- a/lib/ddex/ern/v381/resource_musical_work_reference.rb
+++ b/lib/ddex/ern/v381/resource_musical_work_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ResourceMusicalWorkReference < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceMusicalWorkReference"
+  xml_name "ResourceMusicalWorkReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :duration_used, :from => "DurationUsed", :required => false

--- a/lib/ddex/ern/v381/resource_musical_work_reference_list.rb
+++ b/lib/ddex/ern/v381/resource_musical_work_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ResourceMusicalWorkReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceMusicalWorkReferenceList"
+  xml_name "ResourceMusicalWorkReferenceList"
 
       xml_accessor :resource_musical_work_references, :as => [DDEX::ERN::V381::ResourceMusicalWorkReference], :from => "ResourceMusicalWorkReference", :required => true
 

--- a/lib/ddex/ern/v381/resource_omission_reason.rb
+++ b/lib/ddex/ern/v381/resource_omission_reason.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ResourceOmissionReason < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceOmissionReason"
+  xml_name "ResourceOmissionReason"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/resource_proprietary_id.rb
+++ b/lib/ddex/ern/v381/resource_proprietary_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ResourceProprietaryId < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceProprietaryId"
+  xml_name "ResourceProprietaryId"
 
       xml_accessor :proprietary_ids, :as => [DDEX::ERN::V381::ProprietaryId], :from => "ProprietaryId", :required => true
 

--- a/lib/ddex/ern/v381/resource_type.rb
+++ b/lib/ddex/ern/v381/resource_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::ResourceType < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceType"
+  xml_name "ResourceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/resource_usage.rb
+++ b/lib/ddex/ern/v381/resource_usage.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::ResourceUsage < Element
   include ROXML
 
 
-  xml_name "ns1:ResourceUsage"
+  xml_name "ResourceUsage"
 
       xml_accessor :deal_resource_references, :as => [], :from => "DealResourceReference", :required => false
       xml_accessor :usages, :as => [DDEX::ERN::V381::Usage], :from => "Usage", :required => true

--- a/lib/ddex/ern/v381/right_share.rb
+++ b/lib/ddex/ern/v381/right_share.rb
@@ -30,7 +30,7 @@ class DDEX::ERN::V381::RightShare < Element
   include ROXML
 
 
-  xml_name "ns1:RightShare"
+  xml_name "RightShare"
 
       xml_accessor :right_share_id, :as => DDEX::ERN::V381::RightsAgreementId, :from => "RightShareId", :required => false
       xml_accessor :right_share_reference, :from => "RightShareReference", :required => true

--- a/lib/ddex/ern/v381/right_share_creation_reference_list.rb
+++ b/lib/ddex/ern/v381/right_share_creation_reference_list.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::RightShareCreationReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:RightShareCreationReferenceList"
+  xml_name "RightShareCreationReferenceList"
 
       xml_accessor :right_share_work_references, :as => [], :from => "RightShareWorkReference", :required => false
       xml_accessor :right_share_resource_references, :as => [], :from => "RightShareResourceReference", :required => false

--- a/lib/ddex/ern/v381/rights_agreement_id.rb
+++ b/lib/ddex/ern/v381/rights_agreement_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::RightsAgreementId < Element
   include ROXML
 
 
-  xml_name "ns1:RightsAgreementId"
+  xml_name "RightsAgreementId"
 
       xml_accessor :mwlis, :as => [], :from => "MWLI", :required => false
       xml_accessor :proprietary_ids, :as => [DDEX::ERN::V381::ProprietaryId], :from => "ProprietaryId", :required => false

--- a/lib/ddex/ern/v381/rights_claim_policy.rb
+++ b/lib/ddex/ern/v381/rights_claim_policy.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::RightsClaimPolicy < Element
   include ROXML
 
 
-  xml_name "ns1:RightsClaimPolicy"
+  xml_name "RightsClaimPolicy"
 
       xml_accessor :condition, :as => DDEX::ERN::V381::Condition, :from => "Condition", :required => true
       xml_accessor :rights_claim_policy_type, :from => "RightsClaimPolicyType", :required => true

--- a/lib/ddex/ern/v381/rights_controller.rb
+++ b/lib/ddex/ern/v381/rights_controller.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::RightsController < Element
   include ROXML
 
 
-  xml_name "ns1:RightsController"
+  xml_name "RightsController"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/rights_type.rb
+++ b/lib/ddex/ern/v381/rights_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::RightsType < Element
   include ROXML
 
 
-  xml_name "ns1:RightsType"
+  xml_name "RightsType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/sales_reporting_proxy_release_id.rb
+++ b/lib/ddex/ern/v381/sales_reporting_proxy_release_id.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::SalesReportingProxyReleaseId < Element
   include ROXML
 
 
-  xml_name "ns1:SalesReportingProxyReleaseId"
+  xml_name "SalesReportingProxyReleaseId"
 
       xml_accessor :release_id, :as => DDEX::ERN::V381::ReleaseId, :from => "ReleaseId", :required => true
       xml_accessor :reason, :as => DDEX::ERN::V381::Reason, :from => "Reason", :required => false

--- a/lib/ddex/ern/v381/sampling_rate.rb
+++ b/lib/ddex/ern/v381/sampling_rate.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SamplingRate < Element
   include ROXML
 
 
-  xml_name "ns1:SamplingRate"
+  xml_name "SamplingRate"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/sheet_music.rb
+++ b/lib/ddex/ern/v381/sheet_music.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V381::SheetMusic < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusic"
+  xml_name "SheetMusic"
 
       xml_accessor :sheet_music_type, :as => DDEX::ERN::V381::SheetMusicType, :from => "SheetMusicType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/sheet_music_codec_type.rb
+++ b/lib/ddex/ern/v381/sheet_music_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SheetMusicCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicCodecType"
+  xml_name "SheetMusicCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/sheet_music_details_by_territory.rb
+++ b/lib/ddex/ern/v381/sheet_music_details_by_territory.rb
@@ -29,7 +29,7 @@ class DDEX::ERN::V381::SheetMusicDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicDetailsByTerritory"
+  xml_name "SheetMusicDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/sheet_music_id.rb
+++ b/lib/ddex/ern/v381/sheet_music_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::SheetMusicId < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicId"
+  xml_name "SheetMusicId"
 
       xml_accessor :ismn, :from => "ISMN", :required => false
       xml_accessor :proprietary_ids, :as => [DDEX::ERN::V381::ProprietaryId], :from => "ProprietaryId", :required => false

--- a/lib/ddex/ern/v381/sheet_music_type.rb
+++ b/lib/ddex/ern/v381/sheet_music_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SheetMusicType < Element
   include ROXML
 
 
-  xml_name "ns1:SheetMusicType"
+  xml_name "SheetMusicType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/society_affiliation.rb
+++ b/lib/ddex/ern/v381/society_affiliation.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::SocietyAffiliation < Element
   include ROXML
 
 
-  xml_name "ns1:SocietyAffiliation"
+  xml_name "SocietyAffiliation"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/software.rb
+++ b/lib/ddex/ern/v381/software.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V381::Software < Element
   include ROXML
 
 
-  xml_name "ns1:Software"
+  xml_name "Software"
 
       xml_accessor :software_type, :as => DDEX::ERN::V381::SoftwareType, :from => "SoftwareType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/software_details_by_territory.rb
+++ b/lib/ddex/ern/v381/software_details_by_territory.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V381::SoftwareDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:SoftwareDetailsByTerritory"
+  xml_name "SoftwareDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/software_type.rb
+++ b/lib/ddex/ern/v381/software_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SoftwareType < Element
   include ROXML
 
 
-  xml_name "ns1:SoftwareType"
+  xml_name "SoftwareType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/sound_processor_type.rb
+++ b/lib/ddex/ern/v381/sound_processor_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SoundProcessorType < Element
   include ROXML
 
 
-  xml_name "ns1:SoundProcessorType"
+  xml_name "SoundProcessorType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/sound_recording.rb
+++ b/lib/ddex/ern/v381/sound_recording.rb
@@ -29,7 +29,7 @@ class DDEX::ERN::V381::SoundRecording < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecording"
+  xml_name "SoundRecording"
 
       xml_accessor :sound_recording_type, :as => DDEX::ERN::V381::SoundRecordingType, :from => "SoundRecordingType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/sound_recording_collection_reference.rb
+++ b/lib/ddex/ern/v381/sound_recording_collection_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SoundRecordingCollectionReference < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingCollectionReference"
+  xml_name "SoundRecordingCollectionReference"
 
       xml_accessor :sequence_number, :as => Integer, :from => "SequenceNumber", :required => false
       xml_accessor :sound_recording_collection_reference, :from => "SoundRecordingCollectionReference", :required => true

--- a/lib/ddex/ern/v381/sound_recording_collection_reference_list.rb
+++ b/lib/ddex/ern/v381/sound_recording_collection_reference_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::SoundRecordingCollectionReferenceList < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingCollectionReferenceList"
+  xml_name "SoundRecordingCollectionReferenceList"
 
       xml_accessor :number_of_collections, :as => Integer, :from => "NumberOfCollections", :required => false
       xml_accessor :sound_recording_collection_references, :as => [DDEX::ERN::V381::SoundRecordingCollectionReference], :from => "SoundRecordingCollectionReference", :required => true

--- a/lib/ddex/ern/v381/sound_recording_details_by_territory.rb
+++ b/lib/ddex/ern/v381/sound_recording_details_by_territory.rb
@@ -38,7 +38,7 @@ class DDEX::ERN::V381::SoundRecordingDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingDetailsByTerritory"
+  xml_name "SoundRecordingDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/sound_recording_id.rb
+++ b/lib/ddex/ern/v381/sound_recording_id.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::SoundRecordingId < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingId"
+  xml_name "SoundRecordingId"
 
       xml_accessor :isrc, :from => "ISRC", :required => false
       xml_accessor :catalog_number, :as => DDEX::ERN::V381::CatalogNumber, :from => "CatalogNumber", :required => false

--- a/lib/ddex/ern/v381/sound_recording_preview_details.rb
+++ b/lib/ddex/ern/v381/sound_recording_preview_details.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::SoundRecordingPreviewDetails < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingPreviewDetails"
+  xml_name "SoundRecordingPreviewDetails"
 
       xml_accessor :part_type, :as => DDEX::ERN::V381::Description, :from => "PartType", :required => false
       xml_accessor :start_point, :as => Float, :from => "StartPoint", :required => false

--- a/lib/ddex/ern/v381/sound_recording_type.rb
+++ b/lib/ddex/ern/v381/sound_recording_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SoundRecordingType < Element
   include ROXML
 
 
-  xml_name "ns1:SoundRecordingType"
+  xml_name "SoundRecordingType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/sub_title.rb
+++ b/lib/ddex/ern/v381/sub_title.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::SubTitle < Element
   include ROXML
 
 
-  xml_name "ns1:SubTitle"
+  xml_name "SubTitle"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/synopsis.rb
+++ b/lib/ddex/ern/v381/synopsis.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::Synopsis < Element
   include ROXML
 
 
-  xml_name "ns1:Synopsis"
+  xml_name "Synopsis"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/tariff_reference.rb
+++ b/lib/ddex/ern/v381/tariff_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::TariffReference < Element
   include ROXML
 
 
-  xml_name "ns1:TariffReference"
+  xml_name "TariffReference"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/technical_image_details.rb
+++ b/lib/ddex/ern/v381/technical_image_details.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V381::TechnicalImageDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalImageDetails"
+  xml_name "TechnicalImageDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V381::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v381/technical_instantiation.rb
+++ b/lib/ddex/ern/v381/technical_instantiation.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::TechnicalInstantiation < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalInstantiation"
+  xml_name "TechnicalInstantiation"
 
       xml_accessor :drm_enforcement_type, :from => "DrmEnforcementType", :required => false
       xml_accessor :video_definition_type, :from => "VideoDefinitionType", :required => false

--- a/lib/ddex/ern/v381/technical_midi_details.rb
+++ b/lib/ddex/ern/v381/technical_midi_details.rb
@@ -23,7 +23,7 @@ class DDEX::ERN::V381::TechnicalMidiDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalMidiDetails"
+  xml_name "TechnicalMidiDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :duration, :from => "Duration", :required => false

--- a/lib/ddex/ern/v381/technical_sheet_music_details.rb
+++ b/lib/ddex/ern/v381/technical_sheet_music_details.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V381::TechnicalSheetMusicDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalSheetMusicDetails"
+  xml_name "TechnicalSheetMusicDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V381::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v381/technical_software_details.rb
+++ b/lib/ddex/ern/v381/technical_software_details.rb
@@ -24,7 +24,7 @@ class DDEX::ERN::V381::TechnicalSoftwareDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalSoftwareDetails"
+  xml_name "TechnicalSoftwareDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V381::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v381/technical_sound_recording_details.rb
+++ b/lib/ddex/ern/v381/technical_sound_recording_details.rb
@@ -27,7 +27,7 @@ class DDEX::ERN::V381::TechnicalSoundRecordingDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalSoundRecordingDetails"
+  xml_name "TechnicalSoundRecordingDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V381::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v381/technical_text_details.rb
+++ b/lib/ddex/ern/v381/technical_text_details.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V381::TechnicalTextDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalTextDetails"
+  xml_name "TechnicalTextDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V381::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v381/technical_user_defined_resource_details.rb
+++ b/lib/ddex/ern/v381/technical_user_defined_resource_details.rb
@@ -23,7 +23,7 @@ class DDEX::ERN::V381::TechnicalUserDefinedResourceDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalUserDefinedResourceDetails"
+  xml_name "TechnicalUserDefinedResourceDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :user_defined_values, :as => [DDEX::ERN::V381::UserDefinedValue], :from => "UserDefinedValue", :required => false

--- a/lib/ddex/ern/v381/technical_video_details.rb
+++ b/lib/ddex/ern/v381/technical_video_details.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V381::TechnicalVideoDetails < Element
   include ROXML
 
 
-  xml_name "ns1:TechnicalVideoDetails"
+  xml_name "TechnicalVideoDetails"
 
       xml_accessor :technical_resource_details_reference, :from => "TechnicalResourceDetailsReference", :required => true
       xml_accessor :drm_platform_type, :as => DDEX::ERN::V381::DrmPlatformType, :from => "DrmPlatformType", :required => false

--- a/lib/ddex/ern/v381/text.rb
+++ b/lib/ddex/ern/v381/text.rb
@@ -25,7 +25,7 @@ class DDEX::ERN::V381::Text < Element
   include ROXML
 
 
-  xml_name "ns1:Text"
+  xml_name "Text"
 
       xml_accessor :text_type, :as => DDEX::ERN::V381::TextType, :from => "TextType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/text_codec_type.rb
+++ b/lib/ddex/ern/v381/text_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::TextCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:TextCodecType"
+  xml_name "TextCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/text_details_by_territory.rb
+++ b/lib/ddex/ern/v381/text_details_by_territory.rb
@@ -31,7 +31,7 @@ class DDEX::ERN::V381::TextDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:TextDetailsByTerritory"
+  xml_name "TextDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/text_id.rb
+++ b/lib/ddex/ern/v381/text_id.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::TextId < Element
   include ROXML
 
 
-  xml_name "ns1:TextId"
+  xml_name "TextId"
 
       xml_accessor :isbn, :from => "ISBN", :required => false
       xml_accessor :issn, :from => "ISSN", :required => false

--- a/lib/ddex/ern/v381/text_type.rb
+++ b/lib/ddex/ern/v381/text_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::TextType < Element
   include ROXML
 
 
-  xml_name "ns1:TextType"
+  xml_name "TextType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/title.rb
+++ b/lib/ddex/ern/v381/title.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::Title < Element
   include ROXML
 
 
-  xml_name "ns1:Title"
+  xml_name "Title"
 
       xml_accessor :title_text, :as => DDEX::ERN::V381::TitleText, :from => "TitleText", :required => true
       xml_accessor :sub_titles, :as => [DDEX::ERN::V381::TypedSubTitle], :from => "SubTitle", :required => false

--- a/lib/ddex/ern/v381/title_text.rb
+++ b/lib/ddex/ern/v381/title_text.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::TitleText < Element
   include ROXML
 
 
-  xml_name "ns1:TitleText"
+  xml_name "TitleText"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/typed_rights_controller.rb
+++ b/lib/ddex/ern/v381/typed_rights_controller.rb
@@ -21,7 +21,7 @@ class DDEX::ERN::V381::TypedRightsController < Element
   include ROXML
 
 
-  xml_name "ns1:TypedRightsController"
+  xml_name "TypedRightsController"
 
       xml_accessor :party_names, :as => [DDEX::ERN::V381::PartyName], :from => "PartyName", :required => false
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false

--- a/lib/ddex/ern/v381/typed_sub_title.rb
+++ b/lib/ddex/ern/v381/typed_sub_title.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::TypedSubTitle < Element
   include ROXML
 
 
-  xml_name "ns1:TypedSubTitle"
+  xml_name "TypedSubTitle"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/usage.rb
+++ b/lib/ddex/ern/v381/usage.rb
@@ -22,7 +22,7 @@ class DDEX::ERN::V381::Usage < Element
   include ROXML
 
 
-  xml_name "ns1:Usage"
+  xml_name "Usage"
 
       xml_accessor :use_types, :as => [DDEX::ERN::V381::UseType], :from => "UseType", :required => true
       xml_accessor :user_interface_types, :as => [DDEX::ERN::V381::UserInterfaceType], :from => "UserInterfaceType", :required => false

--- a/lib/ddex/ern/v381/use_type.rb
+++ b/lib/ddex/ern/v381/use_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::UseType < Element
   include ROXML
 
 
-  xml_name "ns1:UseType"
+  xml_name "UseType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/user_defined_resource.rb
+++ b/lib/ddex/ern/v381/user_defined_resource.rb
@@ -26,7 +26,7 @@ class DDEX::ERN::V381::UserDefinedResource < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedResource"
+  xml_name "UserDefinedResource"
 
       xml_accessor :user_defined_resource_type, :as => DDEX::ERN::V381::UserDefinedResourceType, :from => "UserDefinedResourceType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/user_defined_resource_details_by_territory.rb
+++ b/lib/ddex/ern/v381/user_defined_resource_details_by_territory.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V381::UserDefinedResourceDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedResourceDetailsByTerritory"
+  xml_name "UserDefinedResourceDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/user_defined_resource_type.rb
+++ b/lib/ddex/ern/v381/user_defined_resource_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::UserDefinedResourceType < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedResourceType"
+  xml_name "UserDefinedResourceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/user_defined_value.rb
+++ b/lib/ddex/ern/v381/user_defined_value.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::UserDefinedValue < Element
   include ROXML
 
 
-  xml_name "ns1:UserDefinedValue"
+  xml_name "UserDefinedValue"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/user_interface_type.rb
+++ b/lib/ddex/ern/v381/user_interface_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::UserInterfaceType < Element
   include ROXML
 
 
-  xml_name "ns1:UserInterfaceType"
+  xml_name "UserInterfaceType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/video.rb
+++ b/lib/ddex/ern/v381/video.rb
@@ -32,7 +32,7 @@ class DDEX::ERN::V381::Video < Element
   include ROXML
 
 
-  xml_name "ns1:Video"
+  xml_name "Video"
 
       xml_accessor :video_type, :as => DDEX::ERN::V381::VideoType, :from => "VideoType", :required => false
       xml_accessor :artist_related?, :from => "IsArtistRelated", :required => false

--- a/lib/ddex/ern/v381/video_codec_type.rb
+++ b/lib/ddex/ern/v381/video_codec_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::VideoCodecType < Element
   include ROXML
 
 
-  xml_name "ns1:VideoCodecType"
+  xml_name "VideoCodecType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/video_cue_sheet_reference.rb
+++ b/lib/ddex/ern/v381/video_cue_sheet_reference.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::VideoCueSheetReference < Element
   include ROXML
 
 
-  xml_name "ns1:VideoCueSheetReference"
+  xml_name "VideoCueSheetReference"
 
       xml_accessor :video_cue_sheet_reference, :from => "VideoCueSheetReference", :required => true
 

--- a/lib/ddex/ern/v381/video_details_by_territory.rb
+++ b/lib/ddex/ern/v381/video_details_by_territory.rb
@@ -40,7 +40,7 @@ class DDEX::ERN::V381::VideoDetailsByTerritory < Element
   include ROXML
 
 
-  xml_name "ns1:VideoDetailsByTerritory"
+  xml_name "VideoDetailsByTerritory"
 
       xml_accessor :excluded_territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "ExcludedTerritoryCode", :required => false
       xml_accessor :territory_codes, :as => [DDEX::ERN::V381::CurrentTerritoryCode], :from => "TerritoryCode", :required => false

--- a/lib/ddex/ern/v381/video_id.rb
+++ b/lib/ddex/ern/v381/video_id.rb
@@ -19,7 +19,7 @@ class DDEX::ERN::V381::VideoId < Element
   include ROXML
 
 
-  xml_name "ns1:VideoId"
+  xml_name "VideoId"
 
       xml_accessor :isrc, :from => "ISRC", :required => false
       xml_accessor :isan, :from => "ISAN", :required => false

--- a/lib/ddex/ern/v381/video_type.rb
+++ b/lib/ddex/ern/v381/video_type.rb
@@ -17,7 +17,7 @@ class DDEX::ERN::V381::VideoType < Element
   include ROXML
 
 
-  xml_name "ns1:VideoType"
+  xml_name "VideoType"
 
 
     xml_accessor :value, :from => ".", :required => false

--- a/lib/ddex/ern/v381/web_page.rb
+++ b/lib/ddex/ern/v381/web_page.rb
@@ -20,7 +20,7 @@ class DDEX::ERN::V381::WebPage < Element
   include ROXML
 
 
-  xml_name "ns1:WebPage"
+  xml_name "WebPage"
 
       xml_accessor :party_ids, :as => [DDEX::ERN::V381::PartyId], :from => "PartyId", :required => false
       xml_accessor :release_ids, :as => [DDEX::ERN::V381::ReleaseId], :from => "ReleaseId", :required => false

--- a/lib/ddex/ern/v381/web_policy.rb
+++ b/lib/ddex/ern/v381/web_policy.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::WebPolicy < Element
   include ROXML
 
 
-  xml_name "ns1:WebPolicy"
+  xml_name "WebPolicy"
 
       xml_accessor :condition, :as => DDEX::ERN::V381::Condition, :from => "Condition", :required => true
       xml_accessor :access_limitation, :from => "AccessLimitation", :required => false

--- a/lib/ddex/ern/v381/work_list.rb
+++ b/lib/ddex/ern/v381/work_list.rb
@@ -18,7 +18,7 @@ class DDEX::ERN::V381::WorkList < Element
   include ROXML
 
 
-  xml_name "ns1:WorkList"
+  xml_name "WorkList"
 
       xml_accessor :musical_works, :as => [DDEX::ERN::V381::MusicalWork], :from => "MusicalWork", :required => true
 


### PR DESCRIPTION
Was working on generating DDEX XML today and realized that the generated code for 3.8 and 3.8.1 had a `ns1` namespace prepended to the element tag names, i.e.:

https://github.com/sshaw/ddex/blob/v0.0.3/lib/ddex/ern/v381/new_release_message.rb#L29

This results in XML with double namespaces when you use `DDEX.write` which then fails to parse if you try to read it externally (at least in WebKit). This fix removes the extra `ns1` namespace from all the generated classes.

I'm not sure what actually caused the problem: whether it is in the jaxb2xml library, or a dependency, or maybe just need to pass additional arguments when generating the code? I thought I'd add the fix before digging though in case you had an idea what caused the issue.