### PR TITLE
Fix output XML tag order and match ERN XSD definition

### DIFF
--- a/lib/ddex/element.rb
+++ b/lib/ddex/element.rb
@@ -92,6 +92,13 @@ module DDEX
     # TODO: hash()
 
     private
+    # Returns array of internal reference objects, such as attributes
+    # and composed XML objects (superclass attrs first, please).
+    def self.roxml_attrs
+      @roxml_attrs ||= []
+      ((superclass.respond_to?(:roxml_attrs) ? superclass.roxml_attrs : []) + @roxml_attrs).freeze
+    end
+
     def roxml_attributes
       @roxml_attributes ||= begin
         attr = {}


### PR DESCRIPTION
Fixes https://github.com/sshaw/ddex/issues/16

ERN v3.2 XSD defines XML sequences for some elements (enforces elements
order).

`DDEX.write` generates XML with the elements in the wrong order, for example:

```XML
<DisplayArtist>
  <ArtistRole>MainArtist</ArtistRole>
  <PartyName>
    <FullName>Bruno Mars</FullName>
  </PartyName>
</DisplayArtist>
```

however, the valid XML is:

```XML
<DisplayArtist>
  <PartyName>
    <FullName>Bruno Mars</FullName>
  </PartyName>
  <ArtistRole>MainArtist</ArtistRole>
</DisplayArtist>
```

or

```XML
<ImageDetailsByTerritory>
  <TechnicalImageDetails>
    <TechnicalResourceDetailsReference>T12345</TechnicalResourceDetailsReference>
    <ImageCodecType>JPEG</ImageCodecType>
    <ImageHeight>800</ImageHeight>
    <ImageWidth>800</ImageWidth>
    <File>
      <FileName>ABCDEF_T12345.jpg</FileName>
      <FilePath>resources/</FilePath>
      <HashSum>
        <HashSum>aBcDeFgH12345XyZ</HashSum>
        <HashSumAlgorithmType>SHA1</HashSumAlgorithmType>
      </HashSum>
    </File>
  </TechnicalImageDetails>
  <TerritoryCode>Worldwide</TerritoryCode>
</ImageDetailsByTerritory>
```

while the valid XML is:

```XML
<ImageDetailsByTerritory>
  <TerritoryCode>Worldwide</TerritoryCode>
  <TechnicalImageDetails>
    <TechnicalResourceDetailsReference>T12345</TechnicalResourceDetailsReference>
    <ImageCodecType>JPEG</ImageCodecType>
    <ImageHeight>800</ImageHeight>
    <ImageWidth>800</ImageWidth>
    <File>
      <FileName>ABCDEF_T12345.jpg</FileName>
      <FilePath>resources/</FilePath>
      <HashSum>
        <HashSum>aBcDeFgH12345XyZ</HashSum>
        <HashSumAlgorithmType>SHA1</HashSumAlgorithmType>
      </HashSum>
    </File>
  </TechnicalImageDetails>
</ImageDetailsByTerritory>
```

The root of the issue is in classes that include ROXML and inherit from
another class that also includes ROXML, both defining xml_accessors.

ROXML appends superclass `roxml_attrs` to the class in use ones, however,
in order to build valid DDEX XML messages we need to list the superclass
attributes before the ones on the child class (as far as I have been able
to check, be aware, the specification is bloated).

Please, check the classes for the previous XML examples:

```ruby
class DDEX::V20100712::DDEXC::DisplayArtist < DDEX::V20100712::DDEXC::PartyDescriptor
  ...
  xml_accessor :artist_roles, :as => [DDEX::V20100712::DDEXC::ArtistRole], :from => "ArtistRole", :required => false
  ...
end

class DDEX::V20100712::DDEXC::PartyDescriptor < Element
  ...
  xml_accessor :party_names, :as => [DDEX::V20100712::DDEXC::PartyName], :from => "PartyName", :required => false
  ...
end

class DDEX::ERN::V32::ImageDetailsByTerritory < DDEX::V20100712::DDEXC::ImageDetailsByTerritory
  ...
  xml_accessor :technical_image_details, :as => [DDEX::ERN::V32::TechnicalImageDetails], :from => "TechnicalImageDetails", :required => false
  ...
end

class DDEX::V20100712::DDEXC::ImageDetailsByTerritory < Element
  ...
  xml_accessor :excluded_territory_codes, :as => [], :from => "ExcludedTerritoryCode", :required => false
  xml_accessor :territory_codes, :as => [], :from => "TerritoryCode", :required => false
  ...
end
```

As a solution to this issue, DDEX::Element overwrites ROXML module's class
method `roxml_attrs` to prepend the superclass attributes instead.