### PR TITLE
Fix for rack content length

### DIFF
--- a/lib/rack/ddex.rb
+++ b/lib/rack/ddex.rb
@@ -11,7 +11,7 @@ module Rack
         obj  = ::DDEX.read(env["rack.input"])
         json = JSON.dump(obj.to_hash)
 
-        [200, HEADERS.merge("Content-Length" => Rack::Utils.bytesize(json)), [json]]
+        [200, HEADERS.merge("Content-Length" => json.bytesize.to_s), [json]]
       rescue => e
         code = e.is_a?(::DDEX::DDEXError) ? 400 : 500
         json = JSON.dump(:error => e.message)


### PR DESCRIPTION
`.bytesize` no longer exists in `Rack::Utils` but it is part of the [Ruby String API](https://ruby-doc.org/core-1.8.7/String.html#method-i-bytesize).