### PR TITLE
Lowercase response headers

### DIFF
--- a/lib/rack/ddex.rb
+++ b/lib/rack/ddex.rb
@@ -4,14 +4,14 @@ require "ddex"
 
 module Rack
   class DDEX
-    HEADERS = {"Content-Type" => "application/json"}.freeze
+    HEADERS = {"content-type" => "application/json"}.freeze
 
     def call(env)
       begin
         obj  = ::DDEX.read(env["rack.input"])
         json = JSON.dump(obj.to_hash)
 
-        [200, HEADERS.merge("Content-Length" => json.bytesize.to_s), [json]]
+        [200, HEADERS.merge("content-length" => json.bytesize.to_s), [json]]
       rescue => e
         code = e.is_a?(::DDEX::DDEXError) ? 400 : 500
         json = JSON.dump(:error => e.message)


### PR DESCRIPTION
Use lowercase headers to resolve errors due to https://github.com/rack/rack/issues/1592 after upgrading Rack.